### PR TITLE
[Feat] 과외공간 도메인 기능 구현

### DIFF
--- a/src/main/java/turing/turing/domain/code/ConnectionCode.java
+++ b/src/main/java/turing/turing/domain/code/ConnectionCode.java
@@ -17,15 +17,15 @@ public class ConnectionCode extends BaseEntity {
     private Long id;
 
     @NotNull
-    @Column(name = "connection_code", nullable = false)
-    private Integer connectionCode;
+    @Column(name = "code", nullable = false)
+    private Integer code;
 
     @OneToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "study_room_id", nullable = false)
     private StudyRoom studyRoom;
 
-    public ConnectionCode(Integer connectionCode, StudyRoom studyRoom) {
-        this.connectionCode = connectionCode;
+    public ConnectionCode(Integer code, StudyRoom studyRoom) {
+        this.code = code;
         this.studyRoom = studyRoom;
     }
 }

--- a/src/main/java/turing/turing/domain/code/ConnectionCode.java
+++ b/src/main/java/turing/turing/domain/code/ConnectionCode.java
@@ -1,0 +1,26 @@
+package turing.turing.domain.code;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import turing.turing.domain.BaseEntity;
+import turing.turing.domain.studyRoom.StudyRoom;
+
+@Getter
+@Entity
+@NoArgsConstructor
+public class ConnectionCode extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "connection_code_id", nullable = false)
+    private Long id;
+
+    @NotNull
+    @Column(name = "connection_code", nullable = false)
+    private Integer connectionCode;
+
+    @OneToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "study_room_id", nullable = false)
+    private StudyRoom studyRoom;
+}

--- a/src/main/java/turing/turing/domain/code/ConnectionCode.java
+++ b/src/main/java/turing/turing/domain/code/ConnectionCode.java
@@ -23,4 +23,9 @@ public class ConnectionCode extends BaseEntity {
     @OneToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "study_room_id", nullable = false)
     private StudyRoom studyRoom;
+
+    public ConnectionCode(Integer connectionCode, StudyRoom studyRoom) {
+        this.connectionCode = connectionCode;
+        this.studyRoom = studyRoom;
+    }
 }

--- a/src/main/java/turing/turing/domain/code/ConnectionCodeRepository.java
+++ b/src/main/java/turing/turing/domain/code/ConnectionCodeRepository.java
@@ -15,8 +15,9 @@ public interface ConnectionCodeRepository extends JpaRepository<ConnectionCode, 
 
     @Query("select c from ConnectionCode c " +
             "join fetch c.studyRoom sr " +
+            "join fetch sr.student s " +
             "where c.code = :code")
-    Optional<ConnectionCode> findWithStudyRoomByCode(@Param(value = "code") Integer code);
+    Optional<ConnectionCode> findWithStudyRoomAndStudentByCode(@Param(value = "code") Integer code);
 
 
 }

--- a/src/main/java/turing/turing/domain/code/ConnectionCodeRepository.java
+++ b/src/main/java/turing/turing/domain/code/ConnectionCodeRepository.java
@@ -1,0 +1,11 @@
+package turing.turing.domain.code;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import turing.turing.domain.studyRoom.StudyRoom;
+
+import java.util.Optional;
+
+public interface ConnectionCodeRepository extends JpaRepository<ConnectionCode, Long> {
+    Optional<ConnectionCode> findByStudyRoom(StudyRoom studyRoom);
+    Boolean existsByConnectionCode(Integer connectionCode);
+}

--- a/src/main/java/turing/turing/domain/code/ConnectionCodeRepository.java
+++ b/src/main/java/turing/turing/domain/code/ConnectionCodeRepository.java
@@ -13,7 +13,9 @@ public interface ConnectionCodeRepository extends JpaRepository<ConnectionCode, 
 
     Boolean existsByCode(Integer code);
 
-    @Query("select c from ConnectionCode c join fetch c.studyRoom s where c.code = :code")
+    @Query("select c from ConnectionCode c " +
+            "join fetch c.studyRoom sr " +
+            "where c.code = :code")
     Optional<ConnectionCode> findWithStudyRoomByCode(@Param(value = "code") Integer code);
 
 

--- a/src/main/java/turing/turing/domain/code/ConnectionCodeRepository.java
+++ b/src/main/java/turing/turing/domain/code/ConnectionCodeRepository.java
@@ -1,11 +1,20 @@
 package turing.turing.domain.code;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import turing.turing.domain.studyRoom.StudyRoom;
 
 import java.util.Optional;
 
 public interface ConnectionCodeRepository extends JpaRepository<ConnectionCode, Long> {
+
     Optional<ConnectionCode> findByStudyRoom(StudyRoom studyRoom);
-    Boolean existsByConnectionCode(Integer connectionCode);
+
+    Boolean existsByCode(Integer code);
+
+    @Query("select c from ConnectionCode c join fetch c.studyRoom s where c.code = :code")
+    Optional<ConnectionCode> findWithStudyRoomByCode(@Param(value = "code") Integer code);
+
+
 }

--- a/src/main/java/turing/turing/domain/question/Question.java
+++ b/src/main/java/turing/turing/domain/question/Question.java
@@ -1,20 +1,17 @@
 package turing.turing.domain.question;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import turing.turing.domain.BaseEntity;
+import turing.turing.domain.comment.Comment;
 import turing.turing.domain.studyRoom.StudyRoom;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 @Entity
@@ -52,5 +49,8 @@ public class Question extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "study_room_id", nullable = false)
     private StudyRoom studyRoom;
+
+    @OneToMany(mappedBy = "question", cascade = CascadeType.REMOVE)
+    private List<Comment> comments = new ArrayList<>();
 
 }

--- a/src/main/java/turing/turing/domain/schedule/ScheduleRepository.java
+++ b/src/main/java/turing/turing/domain/schedule/ScheduleRepository.java
@@ -1,0 +1,11 @@
+package turing.turing.domain.schedule;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import turing.turing.domain.studyRoom.StudyRoom;
+
+import java.util.List;
+
+public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
+
+    List<Schedule> findAllByStudyRoomOrderByDate(StudyRoom studyRoom);
+}

--- a/src/main/java/turing/turing/domain/student/Student.java
+++ b/src/main/java/turing/turing/domain/student/Student.java
@@ -37,8 +37,7 @@ public class Student extends BaseEntity {
     private String year;
 
     @Size(max = 30)
-    @NotNull
-    @Column(name = "phone", nullable = false, length = 30)
+    @Column(name = "phone", length = 30)
     private String phone;
 
     @Size(max = 30)
@@ -46,7 +45,12 @@ public class Student extends BaseEntity {
     private String parentPhone;
 
     @Size(max = 300)
-    @Column(name = "fcm_token", nullable = false, length = 300)
+    @Column(name = "fcm_token", length = 300)
     private String fcmToken;
 
+    public Student(String name, String school, String year) {
+        this.name = name;
+        this.school = school;
+        this.year = year;
+    }
 }

--- a/src/main/java/turing/turing/domain/student/Student.java
+++ b/src/main/java/turing/turing/domain/student/Student.java
@@ -7,13 +7,15 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import turing.turing.domain.BaseEntity;
 
 @Getter
 @Entity
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Student extends BaseEntity {
 
     @Id
@@ -48,9 +50,12 @@ public class Student extends BaseEntity {
     @Column(name = "fcm_token", length = 300)
     private String fcmToken;
 
-    public Student(String name, String school, String year) {
+    @Builder
+    public Student(String name, String school, String year, String phone, String parentPhone) {
         this.name = name;
         this.school = school;
         this.year = year;
+        this.phone = phone;
+        this.parentPhone = parentPhone;
     }
 }

--- a/src/main/java/turing/turing/domain/student/StudentRepository.java
+++ b/src/main/java/turing/turing/domain/student/StudentRepository.java
@@ -3,4 +3,5 @@ package turing.turing.domain.student;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface StudentRepository extends JpaRepository<Student, Long> {
+
 }

--- a/src/main/java/turing/turing/domain/student/StudentRepository.java
+++ b/src/main/java/turing/turing/domain/student/StudentRepository.java
@@ -1,0 +1,6 @@
+package turing.turing.domain.student;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StudentRepository extends JpaRepository<Student, Long> {
+}

--- a/src/main/java/turing/turing/domain/studyRoom/StudyRoom.java
+++ b/src/main/java/turing/turing/domain/studyRoom/StudyRoom.java
@@ -7,6 +7,10 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import turing.turing.domain.BaseEntity;
+import turing.turing.domain.code.ConnectionCode;
+import turing.turing.domain.exam.Exam;
+import turing.turing.domain.question.Question;
+import turing.turing.domain.schedule.Schedule;
 import turing.turing.domain.student.Student;
 import turing.turing.domain.studyTime.StudyTime;
 import turing.turing.domain.teacher.Teacher;
@@ -47,10 +51,23 @@ public class StudyRoom extends BaseEntity {
     @JoinColumn(name = "student_id", nullable = false)
     private Student student;
 
-    @OneToMany(mappedBy = "studyRoom")
+    @OneToMany(mappedBy = "studyRoom", cascade = CascadeType.REMOVE)
     private List<StudyTime> studyTimes = new ArrayList<>();
 
-            public StudyRoom(String subject, Integer baseSession, Teacher teacher, Student student) {
+    @OneToOne(mappedBy = "studyRoom", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
+    private ConnectionCode connectionCode;
+
+    @OneToMany(mappedBy = "studyRoom", cascade = CascadeType.REMOVE)
+    private List<Schedule> schedules = new ArrayList<>();
+
+    @OneToMany(mappedBy = "studyRoom", cascade = CascadeType.REMOVE)
+    private List<Exam> exams = new ArrayList<>();
+
+
+    @OneToMany(mappedBy = "studyRoom", cascade = CascadeType.REMOVE)
+    private List<Question> questions = new ArrayList<>();
+
+    public StudyRoom(String subject, Integer baseSession, Teacher teacher, Student student) {
         this.subject = subject;
         this.baseSession = baseSession;
         this.teacher = teacher;
@@ -62,6 +79,12 @@ public class StudyRoom extends BaseEntity {
     public void connectStudent(Student student){
         this.student = student;
         this.linkStatus = true;
+    }
+
+    // 다시 nonSignUpStudent와 연결하고 linkStatus를 업데이트함
+    public void disconnectStudent(Student nonSignUpStudent){
+        this.student = nonSignUpStudent;
+        this.linkStatus = false;
     }
 
     public void updateStudyRoom(String subject, Integer baseSession){

--- a/src/main/java/turing/turing/domain/studyRoom/StudyRoom.java
+++ b/src/main/java/turing/turing/domain/studyRoom/StudyRoom.java
@@ -60,4 +60,11 @@ public class StudyRoom extends BaseEntity {
         this.teacher = teacher;
         this.student = student;
     }
+
+    // 기존에는 선생님이 등록해놓은 (가입되지 않은) 학생과 연결되어 있지만
+    // 가입한 학생과 연결 시에 student 참조를 변경해주고, linkStatus를 업데이트 해주어야 함
+    public void connectStudent(Student student){
+        this.student = student;
+        this.linkStatus = true;
+    }
 }

--- a/src/main/java/turing/turing/domain/studyRoom/StudyRoom.java
+++ b/src/main/java/turing/turing/domain/studyRoom/StudyRoom.java
@@ -37,10 +37,6 @@ public class StudyRoom extends BaseEntity {
     @Column(name = "base_session", nullable = false)
     private Integer baseSession;
 
-    @Size(max = 200)
-    @Column(name = "description", length = 200)
-    private String description;
-
     @NotNull
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "teacher_id", nullable = false)

--- a/src/main/java/turing/turing/domain/studyRoom/StudyRoom.java
+++ b/src/main/java/turing/turing/domain/studyRoom/StudyRoom.java
@@ -63,4 +63,9 @@ public class StudyRoom extends BaseEntity {
         this.student = student;
         this.linkStatus = true;
     }
+
+    public void updateStudyRoom(String subject, Integer baseSession){
+        this.subject = subject;
+        this.baseSession = baseSession;
+    }
 }

--- a/src/main/java/turing/turing/domain/studyRoom/StudyRoom.java
+++ b/src/main/java/turing/turing/domain/studyRoom/StudyRoom.java
@@ -1,13 +1,6 @@
 package turing.turing.domain.studyRoom;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.AccessLevel;
@@ -15,7 +8,11 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import turing.turing.domain.BaseEntity;
 import turing.turing.domain.student.Student;
+import turing.turing.domain.studyTime.StudyTime;
 import turing.turing.domain.teacher.Teacher;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 @Entity
@@ -54,7 +51,10 @@ public class StudyRoom extends BaseEntity {
     @JoinColumn(name = "student_id", nullable = false)
     private Student student;
 
-    public StudyRoom(String subject, Integer baseSession, Teacher teacher, Student student) {
+    @OneToMany(mappedBy = "studyRoom")
+    private List<StudyTime> studyTimes = new ArrayList<>();
+
+            public StudyRoom(String subject, Integer baseSession, Teacher teacher, Student student) {
         this.subject = subject;
         this.baseSession = baseSession;
         this.teacher = teacher;

--- a/src/main/java/turing/turing/domain/studyRoom/StudyRoom.java
+++ b/src/main/java/turing/turing/domain/studyRoom/StudyRoom.java
@@ -28,10 +28,6 @@ public class StudyRoom extends BaseEntity {
     private Long id;
 
     @NotNull
-    @Column(name = "code", nullable = false)
-    private Integer code;
-
-    @NotNull
     @Column(name = "link_status", nullable = false)
     private Boolean linkStatus = false;
 
@@ -43,11 +39,6 @@ public class StudyRoom extends BaseEntity {
     @NotNull
     @Column(name = "base_session", nullable = false)
     private Integer baseSession;
-
-    @Size(max = 50)
-    @NotNull
-    @Column(name = "color", nullable = false, length = 50)
-    private String color;
 
     @Size(max = 200)
     @Column(name = "description", length = 200)
@@ -62,4 +53,11 @@ public class StudyRoom extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "student_id", nullable = false)
     private Student student;
+
+    public StudyRoom(String subject, Integer baseSession, Teacher teacher, Student student) {
+        this.subject = subject;
+        this.baseSession = baseSession;
+        this.teacher = teacher;
+        this.student = student;
+    }
 }

--- a/src/main/java/turing/turing/domain/studyRoom/StudyRoomController.java
+++ b/src/main/java/turing/turing/domain/studyRoom/StudyRoomController.java
@@ -30,6 +30,12 @@ public class StudyRoomController {
         return ResponseEntity.ok().build();
     }
 
+    @DeleteMapping("/{studyRoomId}")
+    public ResponseEntity<Void> deleteStudyRoom(@PathVariable Long studyRoomId){
+        studyRoomService.deleteStudyRoom(studyRoomId);
+        return ResponseEntity.ok().build();
+    }
+
     @GetMapping("/{studyRoomId}/codes")
     public ResponseEntity<Integer> getConnectionCode(@PathVariable Long studyRoomId){
         Integer code = studyRoomService.getConnectionCode(studyRoomId);
@@ -40,6 +46,12 @@ public class StudyRoomController {
     @PatchMapping("/connect")
     public ResponseEntity<Void> connectTeacherStudent(@RequestParam(required = true) Integer code){
         studyRoomService.connectTeacherStudent(4L, code);
+        return ResponseEntity.ok().build();
+    }
+
+    @PatchMapping("/{studyRoomId}/disconnect")
+    public ResponseEntity<Void> disconnectTeacherStudent(@PathVariable Long studyRoomId){
+        studyRoomService.disconnectTeacherStudent(studyRoomId);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/turing/turing/domain/studyRoom/StudyRoomController.java
+++ b/src/main/java/turing/turing/domain/studyRoom/StudyRoomController.java
@@ -4,8 +4,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import turing.turing.domain.studyRoom.dto.DetailedStudyRoomResDto;
-import turing.turing.domain.studyRoom.dto.StudyRoomReqDto;
+import turing.turing.domain.studyRoom.dto.StudyRoomCreateReqDto;
 import turing.turing.domain.studyRoom.dto.StudyRoomResDto;
+import turing.turing.domain.studyRoom.dto.StudyRoomUpdateReqDto;
 
 import java.util.List;
 
@@ -18,9 +19,15 @@ public class StudyRoomController {
 
     // 선생님 ID 필요
     @PostMapping
-    public ResponseEntity<Long> createStudyRoom(@RequestBody StudyRoomReqDto studyRoomReqDto){
-        Long studyRoomId = studyRoomService.createStudyRoom(1L, studyRoomReqDto);
+    public ResponseEntity<Long> createStudyRoom(@RequestBody StudyRoomCreateReqDto studyRoomCreateReqDto){
+        Long studyRoomId = studyRoomService.createStudyRoom(1L, studyRoomCreateReqDto);
         return ResponseEntity.ok(studyRoomId);
+    }
+
+    @PutMapping("/{studyRoomId}")
+    public ResponseEntity<Void> updateStudyRoom(@PathVariable Long studyRoomId, @RequestBody StudyRoomUpdateReqDto studyRoomUpdateReqDto){
+        studyRoomService.updateStudyRoom(studyRoomId, studyRoomUpdateReqDto);
+        return ResponseEntity.ok().build();
     }
 
     @GetMapping("/{studyRoomId}/codes")

--- a/src/main/java/turing/turing/domain/studyRoom/StudyRoomController.java
+++ b/src/main/java/turing/turing/domain/studyRoom/StudyRoomController.java
@@ -17,4 +17,10 @@ public class StudyRoomController {
         Long studyRoomId = studyRoomService.createStudyRoom(1L, studyRoomReqDto);
         return ResponseEntity.ok(studyRoomId);
     }
+
+    @GetMapping("/{studyRoomId}/codes")
+    public ResponseEntity<Integer> getConnectionCode(@PathVariable Long studyRoomId){
+        Integer connectionCode = studyRoomService.getConnectionCode(studyRoomId);
+        return ResponseEntity.ok(connectionCode);
+    }
 }

--- a/src/main/java/turing/turing/domain/studyRoom/StudyRoomController.java
+++ b/src/main/java/turing/turing/domain/studyRoom/StudyRoomController.java
@@ -1,0 +1,20 @@
+package turing.turing.domain.studyRoom;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import turing.turing.domain.studyRoom.dto.StudyRoomReqDto;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/study-rooms")
+public class StudyRoomController {
+
+    private final StudyRoomService studyRoomService;
+
+    @PostMapping
+    public ResponseEntity<Long> createStudyRoom(@RequestBody StudyRoomReqDto studyRoomReqDto){
+        Long studyRoomId = studyRoomService.createStudyRoom(1L, studyRoomReqDto);
+        return ResponseEntity.ok(studyRoomId);
+    }
+}

--- a/src/main/java/turing/turing/domain/studyRoom/StudyRoomController.java
+++ b/src/main/java/turing/turing/domain/studyRoom/StudyRoomController.java
@@ -3,6 +3,7 @@ package turing.turing.domain.studyRoom;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import turing.turing.domain.studyRoom.dto.DetailedStudyRoomResDto;
 import turing.turing.domain.studyRoom.dto.StudyRoomReqDto;
 import turing.turing.domain.studyRoom.dto.StudyRoomResDto;
 
@@ -40,5 +41,12 @@ public class StudyRoomController {
     public ResponseEntity<List<StudyRoomResDto>> getStudyRooms(){
         List<StudyRoomResDto> studyRoomResDtoList = studyRoomService.getStudyRooms(1L);
         return ResponseEntity.ok(studyRoomResDtoList);
+    }
+
+    // 학생 or 선생님 ID 필요 (+ role)
+    @GetMapping("/{studyRoomId}")
+    public ResponseEntity<DetailedStudyRoomResDto> getDetailedStudyRooms(@PathVariable Long studyRoomId){
+        DetailedStudyRoomResDto detailedStudyRoomResDto = studyRoomService.getDetailedStudyRooms(studyRoomId);
+        return ResponseEntity.ok(detailedStudyRoomResDto);
     }
 }

--- a/src/main/java/turing/turing/domain/studyRoom/StudyRoomController.java
+++ b/src/main/java/turing/turing/domain/studyRoom/StudyRoomController.java
@@ -4,6 +4,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import turing.turing.domain.studyRoom.dto.StudyRoomReqDto;
+import turing.turing.domain.studyRoom.dto.StudyRoomResDto;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -32,4 +35,10 @@ public class StudyRoomController {
         return ResponseEntity.ok().build();
     }
 
+    // 학생 or 선생님 ID 필요 (+ role)
+    @GetMapping
+    public ResponseEntity<List<StudyRoomResDto>> getStudyRooms(){
+        List<StudyRoomResDto> studyRoomResDtoList = studyRoomService.getStudyRooms(1L);
+        return ResponseEntity.ok(studyRoomResDtoList);
+    }
 }

--- a/src/main/java/turing/turing/domain/studyRoom/StudyRoomController.java
+++ b/src/main/java/turing/turing/domain/studyRoom/StudyRoomController.java
@@ -12,6 +12,7 @@ public class StudyRoomController {
 
     private final StudyRoomService studyRoomService;
 
+    // 선생님 ID 필요
     @PostMapping
     public ResponseEntity<Long> createStudyRoom(@RequestBody StudyRoomReqDto studyRoomReqDto){
         Long studyRoomId = studyRoomService.createStudyRoom(1L, studyRoomReqDto);
@@ -20,7 +21,15 @@ public class StudyRoomController {
 
     @GetMapping("/{studyRoomId}/codes")
     public ResponseEntity<Integer> getConnectionCode(@PathVariable Long studyRoomId){
-        Integer connectionCode = studyRoomService.getConnectionCode(studyRoomId);
-        return ResponseEntity.ok(connectionCode);
+        Integer code = studyRoomService.getConnectionCode(studyRoomId);
+        return ResponseEntity.ok(code);
     }
+
+    // 학생 ID 필요
+    @PatchMapping("/connect")
+    public ResponseEntity<Void> connectTeacherStudent(@RequestParam(required = true) Integer code){
+        studyRoomService.connectTeacherStudent(4L, code);
+        return ResponseEntity.ok().build();
+    }
+
 }

--- a/src/main/java/turing/turing/domain/studyRoom/StudyRoomRepository.java
+++ b/src/main/java/turing/turing/domain/studyRoom/StudyRoomRepository.java
@@ -1,0 +1,6 @@
+package turing.turing.domain.studyRoom;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StudyRoomRepository extends JpaRepository<StudyRoom, Long> {
+}

--- a/src/main/java/turing/turing/domain/studyRoom/StudyRoomRepository.java
+++ b/src/main/java/turing/turing/domain/studyRoom/StudyRoomRepository.java
@@ -16,6 +16,11 @@ public interface StudyRoomRepository extends JpaRepository<StudyRoom, Long> {
     List<StudyRoom> findAllWithStudentByTeacher(@Param(value = "teacher") Teacher teacher);
 
     @Query("select sr from StudyRoom sr " +
+            "join fetch sr.student s " +
+            "where sr.id = :studyRoomId")
+    Optional<StudyRoom> findWithStudentById(@Param(value = "studyRoomId") Long studyRoomId);
+
+    @Query("select distinct sr from StudyRoom sr " +
             "join fetch sr.studyTimes st " +
             "join fetch sr.student s " +
             "where sr.id = :studyRoomId")

--- a/src/main/java/turing/turing/domain/studyRoom/StudyRoomRepository.java
+++ b/src/main/java/turing/turing/domain/studyRoom/StudyRoomRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.repository.query.Param;
 import turing.turing.domain.teacher.Teacher;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface StudyRoomRepository extends JpaRepository<StudyRoom, Long> {
 
@@ -13,4 +14,10 @@ public interface StudyRoomRepository extends JpaRepository<StudyRoom, Long> {
             "join fetch sr.student s " +
             "where sr.teacher = :teacher")
     List<StudyRoom> findAllWithStudentByTeacher(@Param(value = "teacher") Teacher teacher);
+
+    @Query("select sr from StudyRoom sr " +
+            "join fetch sr.studyTimes st " +
+            "join fetch sr.student s " +
+            "where sr.id = :studyRoomId")
+    Optional<StudyRoom> findWithAllStudyTimeAndStudentById(@Param(value = "studyRoomId") Long studyRoomId);
 }

--- a/src/main/java/turing/turing/domain/studyRoom/StudyRoomRepository.java
+++ b/src/main/java/turing/turing/domain/studyRoom/StudyRoomRepository.java
@@ -1,6 +1,16 @@
 package turing.turing.domain.studyRoom;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import turing.turing.domain.teacher.Teacher;
+
+import java.util.List;
 
 public interface StudyRoomRepository extends JpaRepository<StudyRoom, Long> {
+
+    @Query("select sr from StudyRoom sr " +
+            "join fetch sr.student s " +
+            "where sr.teacher = :teacher")
+    List<StudyRoom> findAllWithStudentByTeacher(@Param(value = "teacher") Teacher teacher);
 }

--- a/src/main/java/turing/turing/domain/studyRoom/StudyRoomService.java
+++ b/src/main/java/turing/turing/domain/studyRoom/StudyRoomService.java
@@ -1,13 +1,15 @@
 package turing.turing.domain.studyRoom;
 
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import turing.turing.domain.code.ConnectionCode;
 import turing.turing.domain.code.ConnectionCodeRepository;
+import turing.turing.domain.schedule.Schedule;
+import turing.turing.domain.schedule.ScheduleRepository;
 import turing.turing.domain.student.Student;
 import turing.turing.domain.student.StudentRepository;
+import turing.turing.domain.studyRoom.dto.DetailedStudyRoomResDto;
 import turing.turing.domain.studyRoom.dto.StudyRoomReqDto;
 import turing.turing.domain.studyRoom.dto.StudyRoomResDto;
 import turing.turing.domain.studyTime.StudyTime;
@@ -30,6 +32,7 @@ public class StudyRoomService {
     private final StudentRepository studentRepository;
     private final StudyTimeRepository studyTimeRepository;
     private final ConnectionCodeRepository connectionCodeRepository;
+    private final ScheduleRepository scheduleRepository;
 
     @Transactional
     public Long createStudyRoom(Long teacherId, StudyRoomReqDto studyRoomReqDto) {
@@ -99,6 +102,18 @@ public class StudyRoomService {
 
         List<StudyRoomResDto> studyRoomResDtoList = studyRoomList.stream().map(StudyRoomResDto::of).toList();
         return studyRoomResDtoList;
+    }
+
+    public DetailedStudyRoomResDto getDetailedStudyRooms(Long studyRoomId){
+
+        // role == teacher
+        StudyRoom studyRoom = studyRoomRepository.findWithAllStudyTimeAndStudentById(studyRoomId)
+                .orElseThrow(() -> new RestApiException(CommonErrorCode.NOT_FOUND));
+
+        List<Schedule> scheduleList = scheduleRepository.findAllByStudyRoomOrderByDate(studyRoom);
+
+        DetailedStudyRoomResDto detailedStudyRoomResDto = DetailedStudyRoomResDto.of(studyRoom, scheduleList);
+        return detailedStudyRoomResDto;
     }
 
     // 중복되지 않는 6자리 연결 코드를 생성함

--- a/src/main/java/turing/turing/domain/studyRoom/StudyRoomService.java
+++ b/src/main/java/turing/turing/domain/studyRoom/StudyRoomService.java
@@ -54,25 +54,46 @@ public class StudyRoomService {
 
     @Transactional
     public Integer getConnectionCode(Long studyRoomId){
+
         StudyRoom studyRoom = studyRoomRepository.findById(studyRoomId)
                 .orElseThrow(() -> new RestApiException(CommonErrorCode.NOT_FOUND));
 
+        // 이미 연결된 경우에는 코드를 생성하지 않음
+        if(studyRoom.getLinkStatus())
+            throw new RestApiException(CommonErrorCode.BAD_REQUEST);
+
         // 이미 연결 코드가 존재한다면 그대로 리턴, 존재하지 않는다면 중복되지 않는 연결 코드 생성하여 리턴
         return connectionCodeRepository.findByStudyRoom(studyRoom)
-                .map(ConnectionCode::getConnectionCode)
+                .map(ConnectionCode::getCode)
                 .orElseGet(() -> {
-                    ConnectionCode connectionCode = new ConnectionCode(generateConnectionCode(), studyRoom);
+                    ConnectionCode connectionCode = new ConnectionCode(generateCode(), studyRoom);
                     connectionCodeRepository.save(connectionCode);
-                    return connectionCode.getConnectionCode();
+                    return connectionCode.getCode();
                 });
     }
 
+    @Transactional
+    public void connectTeacherStudent(Long studentId, Integer code){
+
+        Student student = studentRepository.findById(studentId)
+                .orElseThrow(() -> new RestApiException(CommonErrorCode.NOT_FOUND));
+
+        ConnectionCode connectionCode = connectionCodeRepository.findWithStudyRoomByCode(code)
+                .orElseThrow(() -> new RestApiException(CommonErrorCode.NOT_FOUND));
+
+        // 실제로 가입한 학생과 연결 (참조를 변경)
+        connectionCode.getStudyRoom().connectStudent(student);
+
+        // 연결 후, 연결 코드는 삭제됨
+        connectionCodeRepository.delete(connectionCode);
+    }
+
     // 중복되지 않는 6자리 연결 코드를 생성함
-    public Integer generateConnectionCode(){
+    public Integer generateCode(){
         while (true){
             Integer generatedCode = ThreadLocalRandom.current().nextInt(100000, 1000000);  // 6자리 코드 생성
 
-            if(!connectionCodeRepository.existsByConnectionCode(generatedCode))   // 중복되지 않는 코드인지 검증
+            if(!connectionCodeRepository.existsByCode(generatedCode))   // 중복되지 않는 코드인지 검증
                 return generatedCode;
         }
     }

--- a/src/main/java/turing/turing/domain/studyRoom/StudyRoomService.java
+++ b/src/main/java/turing/turing/domain/studyRoom/StudyRoomService.java
@@ -4,6 +4,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import turing.turing.domain.code.ConnectionCode;
+import turing.turing.domain.code.ConnectionCodeRepository;
 import turing.turing.domain.student.Student;
 import turing.turing.domain.student.StudentRepository;
 import turing.turing.domain.studyRoom.dto.StudyRoomReqDto;
@@ -15,6 +17,7 @@ import turing.turing.global.exception.RestApiException;
 import turing.turing.global.exception.errorCode.CommonErrorCode;
 
 import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
 
 @Service
 @RequiredArgsConstructor
@@ -25,6 +28,7 @@ public class StudyRoomService {
     private final TeacherRepository teacherRepository;
     private final StudentRepository studentRepository;
     private final StudyTimeRepository studyTimeRepository;
+    private final ConnectionCodeRepository connectionCodeRepository;
 
     @Transactional
     public Long createStudyRoom(Long teacherId, StudyRoomReqDto studyRoomReqDto) {
@@ -46,5 +50,30 @@ public class StudyRoomService {
          */
 
         return studyRoom.getId();
+    }
+
+    @Transactional
+    public Integer getConnectionCode(Long studyRoomId){
+        StudyRoom studyRoom = studyRoomRepository.findById(studyRoomId)
+                .orElseThrow(() -> new RestApiException(CommonErrorCode.NOT_FOUND));
+
+        // 이미 연결 코드가 존재한다면 그대로 리턴, 존재하지 않는다면 중복되지 않는 연결 코드 생성하여 리턴
+        return connectionCodeRepository.findByStudyRoom(studyRoom)
+                .map(ConnectionCode::getConnectionCode)
+                .orElseGet(() -> {
+                    ConnectionCode connectionCode = new ConnectionCode(generateConnectionCode(), studyRoom);
+                    connectionCodeRepository.save(connectionCode);
+                    return connectionCode.getConnectionCode();
+                });
+    }
+
+    // 중복되지 않는 6자리 연결 코드를 생성함
+    public Integer generateConnectionCode(){
+        while (true){
+            Integer generatedCode = ThreadLocalRandom.current().nextInt(100000, 1000000);  // 6자리 코드 생성
+
+            if(!connectionCodeRepository.existsByConnectionCode(generatedCode))   // 중복되지 않는 코드인지 검증
+                return generatedCode;
+        }
     }
 }

--- a/src/main/java/turing/turing/domain/studyRoom/StudyRoomService.java
+++ b/src/main/java/turing/turing/domain/studyRoom/StudyRoomService.java
@@ -1,0 +1,50 @@
+package turing.turing.domain.studyRoom;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import turing.turing.domain.student.Student;
+import turing.turing.domain.student.StudentRepository;
+import turing.turing.domain.studyRoom.dto.StudyRoomReqDto;
+import turing.turing.domain.studyTime.StudyTime;
+import turing.turing.domain.studyTime.StudyTimeRepository;
+import turing.turing.domain.teacher.Teacher;
+import turing.turing.domain.teacher.TeacherRepository;
+import turing.turing.global.exception.RestApiException;
+import turing.turing.global.exception.errorCode.CommonErrorCode;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class StudyRoomService {
+
+    private final StudyRoomRepository studyRoomRepository;
+    private final TeacherRepository teacherRepository;
+    private final StudentRepository studentRepository;
+    private final StudyTimeRepository studyTimeRepository;
+
+    @Transactional
+    public Long createStudyRoom(Long teacherId, StudyRoomReqDto studyRoomReqDto) {
+
+        Teacher teacher = teacherRepository.findById(teacherId)
+                .orElseThrow(() -> new RestApiException(CommonErrorCode.NOT_FOUND));
+
+        Student student = studyRoomReqDto.toStudent();
+        studentRepository.save(student);
+
+        StudyRoom studyRoom = studyRoomReqDto.toStudyRoom(teacher, student);
+        studyRoomRepository.save(studyRoom);
+
+        List<StudyTime> studyTimes = studyRoomReqDto.studyTimes().stream().map(studyTimeReqDto -> studyTimeReqDto.toEntity(studyRoom)).toList();
+        studyTimeRepository.saveAll(studyTimes);
+
+        /*
+        기준 회차 (스케줄) 생성 필요!
+         */
+
+        return studyRoom.getId();
+    }
+}

--- a/src/main/java/turing/turing/domain/studyRoom/StudyRoomService.java
+++ b/src/main/java/turing/turing/domain/studyRoom/StudyRoomService.java
@@ -10,8 +10,9 @@ import turing.turing.domain.schedule.ScheduleRepository;
 import turing.turing.domain.student.Student;
 import turing.turing.domain.student.StudentRepository;
 import turing.turing.domain.studyRoom.dto.DetailedStudyRoomResDto;
-import turing.turing.domain.studyRoom.dto.StudyRoomReqDto;
+import turing.turing.domain.studyRoom.dto.StudyRoomCreateReqDto;
 import turing.turing.domain.studyRoom.dto.StudyRoomResDto;
+import turing.turing.domain.studyRoom.dto.StudyRoomUpdateReqDto;
 import turing.turing.domain.studyTime.StudyTime;
 import turing.turing.domain.studyTime.StudyTimeRepository;
 import turing.turing.domain.teacher.Teacher;
@@ -35,18 +36,18 @@ public class StudyRoomService {
     private final ScheduleRepository scheduleRepository;
 
     @Transactional
-    public Long createStudyRoom(Long teacherId, StudyRoomReqDto studyRoomReqDto) {
+    public Long createStudyRoom(Long teacherId, StudyRoomCreateReqDto studyRoomCreateReqDto) {
 
         Teacher teacher = teacherRepository.findById(teacherId)
                 .orElseThrow(() -> new RestApiException(CommonErrorCode.NOT_FOUND));
 
-        Student student = studyRoomReqDto.toStudent();
+        Student student = studyRoomCreateReqDto.toStudent();
         studentRepository.save(student);
 
-        StudyRoom studyRoom = studyRoomReqDto.toStudyRoom(teacher, student);
+        StudyRoom studyRoom = studyRoomCreateReqDto.toStudyRoom(teacher, student);
         studyRoomRepository.save(studyRoom);
 
-        List<StudyTime> studyTimes = studyRoomReqDto.studyTimes().stream().map(studyTimeReqDto -> studyTimeReqDto.toEntity(studyRoom)).toList();
+        List<StudyTime> studyTimes = studyRoomCreateReqDto.studyTimes().stream().map(studyTimeReqDto -> studyTimeReqDto.toEntity(studyRoom)).toList();
         studyTimeRepository.saveAll(studyTimes);
 
         /*
@@ -54,6 +55,20 @@ public class StudyRoomService {
          */
 
         return studyRoom.getId();
+    }
+
+    @Transactional
+    public void updateStudyRoom(Long studyRoomId, StudyRoomUpdateReqDto studyRoomUpdateReqDto) {
+
+        StudyRoom studyRoom = studyRoomRepository.findById(studyRoomId)
+                .orElseThrow(() -> new RestApiException(CommonErrorCode.NOT_FOUND));
+
+        studyRoom.updateStudyRoom(studyRoomUpdateReqDto.subject(), studyRoomUpdateReqDto.baseSession());
+
+        // StudyTime의 경우, 요일이 추가/삭제될 수도 있기 때문에 변경 감지가 아닌 기존 StudyTime 삭제 후 다시 생성하도록 함
+        studyTimeRepository.deleteByStudyRoomId(studyRoomId);  // 벌크 연산을 통해 삭제
+        List<StudyTime> studyTimes = studyRoomUpdateReqDto.studyTimes().stream().map(studyTimeReqDto -> studyTimeReqDto.toEntity(studyRoom)).toList();
+        studyTimeRepository.saveAll(studyTimes);
     }
 
     @Transactional

--- a/src/main/java/turing/turing/domain/studyRoom/StudyRoomService.java
+++ b/src/main/java/turing/turing/domain/studyRoom/StudyRoomService.java
@@ -9,6 +9,7 @@ import turing.turing.domain.code.ConnectionCodeRepository;
 import turing.turing.domain.student.Student;
 import turing.turing.domain.student.StudentRepository;
 import turing.turing.domain.studyRoom.dto.StudyRoomReqDto;
+import turing.turing.domain.studyRoom.dto.StudyRoomResDto;
 import turing.turing.domain.studyTime.StudyTime;
 import turing.turing.domain.studyTime.StudyTimeRepository;
 import turing.turing.domain.teacher.Teacher;
@@ -86,6 +87,18 @@ public class StudyRoomService {
 
         // 연결 후, 연결 코드는 삭제됨
         connectionCodeRepository.delete(connectionCode);
+    }
+
+    public List<StudyRoomResDto> getStudyRooms(Long memberId){
+
+        // role == teacher
+        Teacher teacher = teacherRepository.findById(memberId)
+                .orElseThrow(() -> new RestApiException(CommonErrorCode.NOT_FOUND));
+
+        List<StudyRoom> studyRoomList = studyRoomRepository.findAllWithStudentByTeacher(teacher);
+
+        List<StudyRoomResDto> studyRoomResDtoList = studyRoomList.stream().map(StudyRoomResDto::of).toList();
+        return studyRoomResDtoList;
     }
 
     // 중복되지 않는 6자리 연결 코드를 생성함

--- a/src/main/java/turing/turing/domain/studyRoom/StudyRoomService.java
+++ b/src/main/java/turing/turing/domain/studyRoom/StudyRoomService.java
@@ -72,6 +72,15 @@ public class StudyRoomService {
     }
 
     @Transactional
+    public void deleteStudyRoom(Long studyRoomId){
+
+        StudyRoom studyRoom = studyRoomRepository.findById(studyRoomId)
+                .orElseThrow(() -> new RestApiException(CommonErrorCode.NOT_FOUND));
+
+        studyRoomRepository.delete(studyRoom);
+    }
+
+    @Transactional
     public Integer getConnectionCode(Long studyRoomId){
 
         StudyRoom studyRoom = studyRoomRepository.findById(studyRoomId)
@@ -101,16 +110,34 @@ public class StudyRoomService {
                 .orElseThrow(() -> new RestApiException(CommonErrorCode.NOT_FOUND));
 
         // 기존 학생 가져오기
-        Student prevStudent = connectionCode.getStudyRoom().getStudent();
+        Student nonSignUpStudent = connectionCode.getStudyRoom().getStudent();
 
         // 실제로 가입한 학생과 연결 (참조를 변경)
         connectionCode.getStudyRoom().connectStudent(student);
 
         // 기존 학생은 삭제
-        studentRepository.delete(prevStudent);
+        studentRepository.delete(nonSignUpStudent);
 
         // 연결 후, 연결 코드는 삭제됨
         connectionCodeRepository.delete(connectionCode);
+    }
+
+    @Transactional
+    public void disconnectTeacherStudent(Long studyRoomId){
+
+        StudyRoom studyRoom = studyRoomRepository.findWithStudentById(studyRoomId)
+                .orElseThrow(() -> new RestApiException(CommonErrorCode.NOT_FOUND));
+
+        // 기존 학생의 정보를 통해 nonSignedUpStudent 생성
+        Student nonSignUpStudent = new Student(
+                studyRoom.getStudent().getName(),
+                studyRoom.getStudent().getSchool(),
+                studyRoom.getStudent().getYear(),
+                studyRoom.getStudent().getPhone(),
+                studyRoom.getStudent().getParentPhone()
+        );
+        studentRepository.save(nonSignUpStudent);
+        studyRoom.disconnectStudent(nonSignUpStudent);
     }
 
     public List<StudyRoomResDto> getStudyRooms(Long memberId){

--- a/src/main/java/turing/turing/domain/studyRoom/StudyRoomService.java
+++ b/src/main/java/turing/turing/domain/studyRoom/StudyRoomService.java
@@ -82,11 +82,17 @@ public class StudyRoomService {
         Student student = studentRepository.findById(studentId)
                 .orElseThrow(() -> new RestApiException(CommonErrorCode.NOT_FOUND));
 
-        ConnectionCode connectionCode = connectionCodeRepository.findWithStudyRoomByCode(code)
+        ConnectionCode connectionCode = connectionCodeRepository.findWithStudyRoomAndStudentByCode(code)
                 .orElseThrow(() -> new RestApiException(CommonErrorCode.NOT_FOUND));
+
+        // 기존 학생 가져오기
+        Student prevStudent = connectionCode.getStudyRoom().getStudent();
 
         // 실제로 가입한 학생과 연결 (참조를 변경)
         connectionCode.getStudyRoom().connectStudent(student);
+
+        // 기존 학생은 삭제
+        studentRepository.delete(prevStudent);
 
         // 연결 후, 연결 코드는 삭제됨
         connectionCodeRepository.delete(connectionCode);

--- a/src/main/java/turing/turing/domain/studyRoom/dto/DetailedStudyRoomResDto.java
+++ b/src/main/java/turing/turing/domain/studyRoom/dto/DetailedStudyRoomResDto.java
@@ -6,6 +6,7 @@ import turing.turing.domain.studyRoom.StudyRoom;
 import turing.turing.domain.studyTime.dto.StudyTimeResDto;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 public record DetailedStudyRoomResDto(
@@ -23,8 +24,24 @@ public record DetailedStudyRoomResDto(
         Integer totalBaseSession
 ) {
     public static DetailedStudyRoomResDto of(StudyRoom studyRoom, List<Schedule> schedules) {
+
+        // 수업 시작일
         LocalDate firstSchedule = schedules.isEmpty() ? null : schedules.get(0).getDate();
-        Integer curSession = schedules.isEmpty() ? 0 : schedules.get(schedules.size() - 1).getSession();
+
+        // 현재 회차 / 총 회차 계산
+        Schedule schedule = null;
+        int i = schedules.size() - 1;
+        while (i >= 0) {
+            schedule = schedules.get(i);
+            LocalDateTime scheduleDateTime = LocalDateTime.of(schedule.getDate(), schedule.getEndTime());
+            if(scheduleDateTime.isBefore(LocalDateTime.now()))  // 날짜 역순으로 조회하며, 현재 시간보다 과거인 스케줄을 기준으로 현재 회차를 계산
+                break;
+            i--;
+        }
+        Integer curSession = (schedule == null || i < 0 ? 0 : schedule.getSession());
+        Integer curBaseSession = (schedule == null ? 0 : studyRoom.getBaseSession());
+        Integer totalSession = (schedule == null || i < 0 ? 0 : i+1);
+        Integer totalBaseSession = (schedule == null ? 0: schedules.size());
 
         return new DetailedStudyRoomResDto(
                 studyRoom.getStudent().getName(),
@@ -35,9 +52,9 @@ public record DetailedStudyRoomResDto(
                 studyRoom.getBaseSession(),
                 firstSchedule,
                 curSession,
-                studyRoom.getBaseSession(),
-                schedules.size(),
-                (schedules.size() / studyRoom.getBaseSession() + 1) * studyRoom.getBaseSession()
+                curBaseSession,
+                totalSession,
+                totalBaseSession
         );
     }
 }

--- a/src/main/java/turing/turing/domain/studyRoom/dto/DetailedStudyRoomResDto.java
+++ b/src/main/java/turing/turing/domain/studyRoom/dto/DetailedStudyRoomResDto.java
@@ -1,0 +1,43 @@
+package turing.turing.domain.studyRoom.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import turing.turing.domain.schedule.Schedule;
+import turing.turing.domain.studyRoom.StudyRoom;
+import turing.turing.domain.studyTime.dto.StudyTimeResDto;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record DetailedStudyRoomResDto(
+        String studentName,
+        String subject,
+        String studentSchool,
+        String studentYear,
+        List<StudyTimeResDto> studyTimes,
+        Integer baseSession,
+        @JsonFormat(pattern = "yyyy-MM-dd")
+        LocalDate firstSchedule,
+        Integer curSession,
+        Integer curBaseSession,
+        Integer totalSession,
+        Integer totalBaseSession
+) {
+    public static DetailedStudyRoomResDto of(StudyRoom studyRoom, List<Schedule> schedules) {
+        LocalDate firstSchedule = schedules.isEmpty() ? null : schedules.get(0).getDate();
+        Integer curSession = schedules.isEmpty() ? 0 : schedules.get(schedules.size() - 1).getSession();
+
+        return new DetailedStudyRoomResDto(
+                studyRoom.getStudent().getName(),
+                studyRoom.getSubject(),
+                studyRoom.getStudent().getSchool(),
+                studyRoom.getStudent().getYear(),
+                studyRoom.getStudyTimes().stream().map(StudyTimeResDto::of).toList(),
+                studyRoom.getBaseSession(),
+                firstSchedule,
+                curSession,
+                studyRoom.getBaseSession(),
+                schedules.size(),
+                (schedules.size() / studyRoom.getBaseSession() + 1) * studyRoom.getBaseSession()
+        );
+    }
+}

--- a/src/main/java/turing/turing/domain/studyRoom/dto/StudyRoomCreateReqDto.java
+++ b/src/main/java/turing/turing/domain/studyRoom/dto/StudyRoomCreateReqDto.java
@@ -20,7 +20,7 @@ public record StudyRoomCreateReqDto(
         LocalDate startDate
 ) {
         public Student toStudent(){
-                return new Student(studentName, studentSchool, studentYear);
+                return new Student(studentName, studentSchool, studentYear, null, null);
         }
 
         public StudyRoom toStudyRoom(Teacher teacher, Student student) {

--- a/src/main/java/turing/turing/domain/studyRoom/dto/StudyRoomCreateReqDto.java
+++ b/src/main/java/turing/turing/domain/studyRoom/dto/StudyRoomCreateReqDto.java
@@ -9,7 +9,7 @@ import turing.turing.domain.teacher.Teacher;
 import java.time.LocalDate;
 import java.util.List;
 
-public record StudyRoomReqDto(
+public record StudyRoomCreateReqDto(
         String studentName,
         String studentSchool,
         String studentYear,

--- a/src/main/java/turing/turing/domain/studyRoom/dto/StudyRoomReqDto.java
+++ b/src/main/java/turing/turing/domain/studyRoom/dto/StudyRoomReqDto.java
@@ -1,0 +1,30 @@
+package turing.turing.domain.studyRoom.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import turing.turing.domain.student.Student;
+import turing.turing.domain.studyRoom.StudyRoom;
+import turing.turing.domain.studyTime.dto.StudyTimeReqDto;
+import turing.turing.domain.teacher.Teacher;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record StudyRoomReqDto(
+        String studentName,
+        String studentSchool,
+        String studentYear,
+        String subject,
+        Integer baseSession,
+        List<StudyTimeReqDto> studyTimes,
+        @JsonFormat(pattern = "yyyy-MM-dd")
+        LocalDate startDate
+) {
+        public Student toStudent(){
+                return new Student(studentName, studentSchool, studentYear);
+        }
+
+        public StudyRoom toStudyRoom(Teacher teacher, Student student) {
+                return new StudyRoom(subject, baseSession, teacher, student);
+        }
+
+}

--- a/src/main/java/turing/turing/domain/studyRoom/dto/StudyRoomResDto.java
+++ b/src/main/java/turing/turing/domain/studyRoom/dto/StudyRoomResDto.java
@@ -1,0 +1,19 @@
+package turing.turing.domain.studyRoom.dto;
+
+import turing.turing.domain.studyRoom.StudyRoom;
+
+public record StudyRoomResDto(
+        Long id,
+        String studentName,
+        String subject,
+        Boolean linkStatus
+) {
+    public static StudyRoomResDto of(StudyRoom studyRoom) {
+        return new StudyRoomResDto(
+                studyRoom.getId(),
+                studyRoom.getStudent().getName(),
+                studyRoom.getSubject(),
+                studyRoom.getLinkStatus()
+        );
+    }
+}

--- a/src/main/java/turing/turing/domain/studyRoom/dto/StudyRoomUpdateReqDto.java
+++ b/src/main/java/turing/turing/domain/studyRoom/dto/StudyRoomUpdateReqDto.java
@@ -1,0 +1,16 @@
+package turing.turing.domain.studyRoom.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import turing.turing.domain.studyTime.dto.StudyTimeReqDto;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record StudyRoomUpdateReqDto(
+        String subject,
+        List<StudyTimeReqDto> studyTimes,
+        Integer baseSession,
+        @JsonFormat(pattern = "yyyy-MM-dd")
+        LocalDate startDate
+) {
+}

--- a/src/main/java/turing/turing/domain/studyTime/StudyTime.java
+++ b/src/main/java/turing/turing/domain/studyTime/StudyTime.java
@@ -1,4 +1,4 @@
-package turing.turing.domain.studyDatetime;
+package turing.turing.domain.studyTime;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -18,11 +18,11 @@ import turing.turing.domain.studyRoom.StudyRoom;
 @Getter
 @Entity
 @NoArgsConstructor
-public class StudyDatetime extends BaseEntity {
+public class StudyTime extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "study_datetime_id", nullable = false)
+    @Column(name = "study_time_id", nullable = false)
     private Long id;
 
     @NotNull
@@ -42,4 +42,10 @@ public class StudyDatetime extends BaseEntity {
     @JoinColumn(name = "study_room_id", nullable = false)
     private StudyRoom studyRoom;
 
+    public StudyTime(Integer day, LocalTime startTime, LocalTime endTime, StudyRoom studyRoom) {
+        this.day = day;
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.studyRoom = studyRoom;
+    }
 }

--- a/src/main/java/turing/turing/domain/studyTime/StudyTimeRepository.java
+++ b/src/main/java/turing/turing/domain/studyTime/StudyTimeRepository.java
@@ -1,0 +1,6 @@
+package turing.turing.domain.studyTime;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StudyTimeRepository extends JpaRepository<StudyTime, Long> {
+}

--- a/src/main/java/turing/turing/domain/studyTime/StudyTimeRepository.java
+++ b/src/main/java/turing/turing/domain/studyTime/StudyTimeRepository.java
@@ -1,6 +1,14 @@
 package turing.turing.domain.studyTime;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface StudyTimeRepository extends JpaRepository<StudyTime, Long> {
+
+    // 벌크 연산 활용
+    @Modifying
+    @Query("DELETE FROM StudyTime st WHERE st.studyRoom.id = :studyRoomId")
+    void deleteByStudyRoomId(@Param("studyRoomId") Long studyRoomId);
 }

--- a/src/main/java/turing/turing/domain/studyTime/dto/StudyTimeReqDto.java
+++ b/src/main/java/turing/turing/domain/studyTime/dto/StudyTimeReqDto.java
@@ -1,0 +1,19 @@
+package turing.turing.domain.studyTime.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import turing.turing.domain.studyRoom.StudyRoom;
+import turing.turing.domain.studyTime.StudyTime;
+
+import java.time.LocalTime;
+
+public record StudyTimeReqDto(
+        Integer day,
+        @JsonFormat(pattern = "HH:mm")
+        LocalTime startTime,
+        @JsonFormat(pattern = "HH:mm")
+        LocalTime endTime
+) {
+        public StudyTime toEntity(StudyRoom studyRoom){
+                return new StudyTime(day, startTime, endTime, studyRoom);
+        }
+}

--- a/src/main/java/turing/turing/domain/studyTime/dto/StudyTimeResDto.java
+++ b/src/main/java/turing/turing/domain/studyTime/dto/StudyTimeResDto.java
@@ -1,0 +1,18 @@
+package turing.turing.domain.studyTime.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import turing.turing.domain.studyTime.StudyTime;
+
+import java.time.LocalTime;
+
+public record StudyTimeResDto(
+        Integer day,
+        @JsonFormat(pattern = "HH:mm")
+        LocalTime startTime,
+        @JsonFormat(pattern = "HH:mm")
+        LocalTime endTime
+) {
+        public static StudyTimeResDto of(StudyTime studyTime){
+                return new StudyTimeResDto(studyTime.getDay(), studyTime.getStartTime(), studyTime.getEndTime());
+        }
+}

--- a/src/main/java/turing/turing/domain/teacher/Teacher.java
+++ b/src/main/java/turing/turing/domain/teacher/Teacher.java
@@ -7,13 +7,14 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import turing.turing.domain.BaseEntity;
 
 @Getter
 @Entity
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Teacher extends BaseEntity {
 
     @Id

--- a/src/main/java/turing/turing/domain/teacher/TeacherRepository.java
+++ b/src/main/java/turing/turing/domain/teacher/TeacherRepository.java
@@ -1,0 +1,6 @@
+package turing.turing.domain.teacher;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TeacherRepository extends JpaRepository<Teacher, Long> {
+}


### PR DESCRIPTION
## 📄 Description

- close : #18 

> 과외공간 도메인의 기능을 구현

## 📌 구현 내용

- [x] [과외공간] 과외 정보 등록하기 -> **선택한 수업 시작일 기준으로 스케줄 생성 필요!!!**
- [x] [과외공간] 과외 정보 수정하기 (new)
- [x] [과외공간] 과외 정보 삭제하기 (new)
- [x] [과외공간] 선생님-학생 연결 코드 조회 (코드 생성)
- [x] [과외공간] 선생님-학생 연결 -> **학생 화면 나온 후 검토**
- [x] [과외공간] 진행중인 수업 조회 (+ 연결 여부) -> **추후 학생 요청도 처리하도록 해야함**
- [x] [과외공간] 진행중인 수업 상세 조회 -> **추후 학생 요청도 처리하도록 해야함**
- [x] [과외공간] 선생님-학생 연결 끊기 (new)

## 📄 참고

- 과외공간의 '연결코드 필드'는 '연결코드(ConnectionCode) 엔티티'로 대체되었습니다.
과외공간이 생성된 시점에 연결 코드도 생성되며, 연결 전까지만 존재하고 학생 연결 시에는 코드가 삭제됩니다. 
(숫자 6자리밖에 안되어 우리 서비스가 엄청 커질 것을 고려해 과외공간 테이블에 영구적으로 두지 않기로 결정하였습니다!)

- ERD에서 StudyDatetime -> StudyTime으로 변경했습니다! (Datetime은 오해의 소지가 있어보여서요)

- 학생 테이블의 FCM 토큰 컬럼 NOT NULL 조건 삭제 (연결 안된 학생은 NULL입니다)

- color, description 필드 삭제

## 🌱 Etc

- 아마 컨트롤러에서 Authentication을 통해 role, memberId 가져올 것 같아서 그 부분은 아래처럼 임의로 넣어주고 진행하였습니다.
```java
    // 선생님 ID 필요
    @PostMapping
    public ResponseEntity<Long> createStudyRoom(@RequestBody StudyRoomReqDto studyRoomReqDto){
        Long studyRoomId = studyRoomService.createStudyRoom(1L, studyRoomReqDto);
        return ResponseEntity.ok(studyRoomId);
    }
```

- 기존 StudyTime 삭제를 위해 **벌크 연산**을 활용해보았습니다!
  insert도 벌크 연산이 가능한지 공부해보았으나, 기본키 생성 전략으로 IDENTITY를 사용하고 있다면 [여기](https://velog.io/@dongvelop/Spring-Data-JPA-Batch-Insert%EB%A1%9C-%ED%95%9C%EB%B2%88%EC%97%90-%EB%8D%B0%EC%9D%B4%ED%84%B0-%EC%82%BD%EC%9E%85%ED%95%98%EA%B8%B0)에서의 설정 파일 수정하는 방법을 사용할 수 없었습니다.
  [여기](https://sabarada.tistory.com/220)에서 JdbcTemplate을 활용할 수 있다는 것은 알게 되었으나 적용하진 않았습니다.

- 연관된 엔티티들과 양방향 매핑을 만들고, 과외 공간(수업) 삭제 시 CascadeType.REMOVE가 적용되도록 하였습니다.
  그러면서 StudyRoom에서 ConnectionCode가 강제로 즉시로딩되는 문제가 발생했습니다만, 대상 테이블에 외래키를 둔 일대일 양방향 관계에서 프록시의 한계로 인해 필연적으로 발생하는 문제로, 일단 보류해두고 리팩토링하면서 해결해보도록 하겠습니다.