### PR TITLE
[Fix] Security Config 수정

### DIFF
--- a/src/main/java/turing/turing/domain/auth/AuthController.java
+++ b/src/main/java/turing/turing/domain/auth/AuthController.java
@@ -1,0 +1,37 @@
+package turing.turing.domain.auth;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import turing.turing.domain.auth.apple.VerifyAppleRequest;
+import turing.turing.domain.auth.dto.LoginRequest;
+import turing.turing.domain.auth.dto.LoginResponse;
+import turing.turing.domain.auth.jwt.TokenResponse;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/auth")
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/verify/apple")
+    public ResponseEntity<TokenResponse> verifyAppleEmail(@RequestBody @Valid VerifyAppleRequest request) {
+        String email = authService.verifyWithApple(request);
+
+        return ResponseEntity.ok(authService.confirmAssign(email));
+    }
+
+    @GetMapping("/login")
+    public ResponseEntity<LoginResponse> login(@RequestBody @Valid LoginRequest request) {
+        LoginResponse response = authService.login(request);
+
+        return ResponseEntity.ok(response);
+    }
+
+}

--- a/src/main/java/turing/turing/domain/auth/AuthController.java
+++ b/src/main/java/turing/turing/domain/auth/AuthController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.RestController;
 import turing.turing.domain.auth.apple.VerifyAppleRequest;
 import turing.turing.domain.auth.dto.LoginRequest;
 import turing.turing.domain.auth.dto.LoginResponse;
+import turing.turing.domain.auth.dto.TokenReIssueRequest;
 import turing.turing.domain.auth.jwt.TokenResponse;
 
 @RestController
@@ -34,4 +35,10 @@ public class AuthController {
         return ResponseEntity.ok(response);
     }
 
+    @PostMapping("/reissue")
+    public ResponseEntity<TokenResponse> reissue(@RequestBody @Valid TokenReIssueRequest request) {
+        TokenResponse response = authService.reissue(request);
+
+        return ResponseEntity.ok(response);
+    }
 }

--- a/src/main/java/turing/turing/domain/auth/AuthService.java
+++ b/src/main/java/turing/turing/domain/auth/AuthService.java
@@ -1,0 +1,87 @@
+package turing.turing.domain.auth;
+
+import io.jsonwebtoken.Claims;
+import java.security.PublicKey;
+import java.util.Map;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import turing.turing.domain.Role;
+import turing.turing.domain.auth.apple.AppleClient;
+import turing.turing.domain.auth.apple.ApplePublicKeyGenerator;
+import turing.turing.domain.auth.apple.ApplePublicKeys;
+import turing.turing.domain.auth.apple.VerifyAppleRequest;
+import turing.turing.domain.auth.apple.AppleTokenParser;
+import turing.turing.domain.auth.dto.LoginRequest;
+import turing.turing.domain.auth.dto.LoginResponse;
+import turing.turing.domain.auth.jwt.JwtTokenProvider;
+import turing.turing.domain.auth.jwt.TokenResponse;
+import turing.turing.domain.student.Student;
+import turing.turing.domain.student.StudentRepository;
+import turing.turing.domain.teacher.Teacher;
+import turing.turing.domain.teacher.TeacherRepository;
+import turing.turing.global.exception.RestApiException;
+import turing.turing.global.exception.errorCode.CommonErrorCode;
+
+@RequiredArgsConstructor
+@Component
+public class AuthService {
+
+    private final AppleTokenParser appleTokenParser;
+    private final AppleClient appleClient;
+    private final ApplePublicKeyGenerator applePublicKeyGenerator;
+    private final TeacherRepository teacherRepository;
+    private final StudentRepository studentRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Transactional
+    public String verifyWithApple(final VerifyAppleRequest request) {
+        String appleIdToken = request.getAppleIdToken();
+        Map<String, String> appleTokenHeader = appleTokenParser.parseHeader(appleIdToken);
+        ApplePublicKeys applePublicKeys = appleClient.getApplePublicKeys();
+        PublicKey publicKey = applePublicKeyGenerator.generate(appleTokenHeader, applePublicKeys);
+        Claims claims = appleTokenParser.extractClaims(appleIdToken, publicKey);
+
+        return claims.get("email", String.class);
+    }
+
+    @Transactional
+    public TokenResponse confirmAssign(String email) {
+        Optional<Teacher> teacher = teacherRepository.findByEmail(email);
+        Optional<Student> student = studentRepository.findByEmail(email);
+
+        String accessToken = null;
+        String refreshToken = null;
+        if (teacher.isPresent()) {
+            accessToken = jwtTokenProvider.createAccessToken(email, Role.TEACHER);
+            refreshToken = jwtTokenProvider.createRefreshToken(email);
+        } else if (student.isPresent()) {
+            accessToken = jwtTokenProvider.createAccessToken(email, Role.STUDENT);
+            refreshToken = jwtTokenProvider.createRefreshToken(email);
+        }
+
+        return new TokenResponse(email, accessToken, refreshToken);
+    }
+
+    @Transactional
+    public LoginResponse login(LoginRequest request) {
+        String token = request.getAccessToken();
+        if (!jwtTokenProvider.validationToken(token)) {
+            throw new IllegalArgumentException("Invalid or expired token");
+        }
+
+        String email = jwtTokenProvider.getEmailFromToken(token);
+        Role role = jwtTokenProvider.getRoleFromToken(token);
+
+        if (role.equals(Role.TEACHER)) {
+            Teacher teacher = teacherRepository.findByEmail(email)
+                    .orElseThrow(() -> new RestApiException(CommonErrorCode.NOT_FOUND));
+            return new LoginResponse(role, teacher.getId());
+        } else {
+            Student student = studentRepository.findByEmail(email)
+                    .orElseThrow(() -> new RestApiException(CommonErrorCode.NOT_FOUND));
+            return new LoginResponse(role, student.getId());
+        }
+    }
+}

--- a/src/main/java/turing/turing/domain/auth/AuthService.java
+++ b/src/main/java/turing/turing/domain/auth/AuthService.java
@@ -15,6 +15,7 @@ import turing.turing.domain.auth.apple.VerifyAppleRequest;
 import turing.turing.domain.auth.apple.AppleTokenParser;
 import turing.turing.domain.auth.dto.LoginRequest;
 import turing.turing.domain.auth.dto.LoginResponse;
+import turing.turing.domain.auth.dto.TokenReIssueRequest;
 import turing.turing.domain.auth.jwt.JwtTokenProvider;
 import turing.turing.domain.auth.jwt.TokenResponse;
 import turing.turing.domain.student.Student;
@@ -26,6 +27,7 @@ import turing.turing.global.exception.errorCode.CommonErrorCode;
 
 @RequiredArgsConstructor
 @Component
+@Transactional(readOnly = true)
 public class AuthService {
 
     private final AppleTokenParser appleTokenParser;
@@ -35,7 +37,6 @@ public class AuthService {
     private final StudentRepository studentRepository;
     private final JwtTokenProvider jwtTokenProvider;
 
-    @Transactional
     public String verifyWithApple(final VerifyAppleRequest request) {
         String appleIdToken = request.getAppleIdToken();
         Map<String, String> appleTokenHeader = appleTokenParser.parseHeader(appleIdToken);
@@ -46,7 +47,6 @@ public class AuthService {
         return claims.get("email", String.class);
     }
 
-    @Transactional
     public TokenResponse confirmAssign(String email) {
         Optional<Teacher> teacher = teacherRepository.findByEmail(email);
         Optional<Student> student = studentRepository.findByEmail(email);
@@ -64,7 +64,6 @@ public class AuthService {
         return new TokenResponse(email, accessToken, refreshToken);
     }
 
-    @Transactional
     public LoginResponse login(LoginRequest request) {
         String token = request.getAccessToken();
         if (!jwtTokenProvider.validationToken(token)) {
@@ -82,6 +81,21 @@ public class AuthService {
             Student student = studentRepository.findByEmail(email)
                     .orElseThrow(() -> new RestApiException(CommonErrorCode.NOT_FOUND));
             return new LoginResponse(role, student.getId());
+        }
+    }
+
+    public TokenResponse reissue(TokenReIssueRequest request) {
+        String token = request.getRefreshToken();
+
+        if (jwtTokenProvider.validationToken(token)) {
+            String email = jwtTokenProvider.getEmailFromToken(token);
+            Role role = jwtTokenProvider.getRoleFromToken(token);
+            String accessToken = jwtTokenProvider.createAccessToken(email, role);
+            String refreshToken = jwtTokenProvider.createRefreshToken(email);
+
+            return new TokenResponse(email, accessToken, refreshToken);
+        } else {
+            throw new IllegalArgumentException("Expired Refresh token");
         }
     }
 }

--- a/src/main/java/turing/turing/domain/auth/AuthService.java
+++ b/src/main/java/turing/turing/domain/auth/AuthService.java
@@ -54,10 +54,10 @@ public class AuthService {
         String accessToken = null;
         String refreshToken = null;
         if (teacher.isPresent()) {
-            accessToken = jwtTokenProvider.createAccessToken(email, Role.TEACHER);
+            accessToken = jwtTokenProvider.createAccessToken(email, teacher.get().getId(), Role.TEACHER);
             refreshToken = jwtTokenProvider.createRefreshToken(email);
         } else if (student.isPresent()) {
-            accessToken = jwtTokenProvider.createAccessToken(email, Role.STUDENT);
+            accessToken = jwtTokenProvider.createAccessToken(email, student.get().getId(), Role.STUDENT);
             refreshToken = jwtTokenProvider.createRefreshToken(email);
         }
 
@@ -90,7 +90,9 @@ public class AuthService {
         if (jwtTokenProvider.validationToken(token)) {
             String email = jwtTokenProvider.getEmailFromToken(token);
             Role role = jwtTokenProvider.getRoleFromToken(token);
-            String accessToken = jwtTokenProvider.createAccessToken(email, role);
+            Long memberId = jwtTokenProvider.getMemberIdFromToken(token);
+
+            String accessToken = jwtTokenProvider.createAccessToken(email, memberId, role);
             String refreshToken = jwtTokenProvider.createRefreshToken(email);
 
             return new TokenResponse(email, accessToken, refreshToken);

--- a/src/main/java/turing/turing/domain/auth/AuthService.java
+++ b/src/main/java/turing/turing/domain/auth/AuthService.java
@@ -76,11 +76,11 @@ public class AuthService {
         if (role.equals(Role.TEACHER)) {
             Teacher teacher = teacherRepository.findByEmail(email)
                     .orElseThrow(() -> new RestApiException(CommonErrorCode.NOT_FOUND));
-            return new LoginResponse(role, teacher.getId());
+            return new LoginResponse(role, teacher.getId(), teacher.getName());
         } else {
             Student student = studentRepository.findByEmail(email)
                     .orElseThrow(() -> new RestApiException(CommonErrorCode.NOT_FOUND));
-            return new LoginResponse(role, student.getId());
+            return new LoginResponse(role, student.getId(), student.getName());
         }
     }
 

--- a/src/main/java/turing/turing/domain/auth/CustomUserDetailService.java
+++ b/src/main/java/turing/turing/domain/auth/CustomUserDetailService.java
@@ -1,0 +1,35 @@
+package turing.turing.domain.auth;
+
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import turing.turing.domain.student.StudentRepository;
+import turing.turing.domain.teacher.TeacherRepository;
+import turing.turing.global.exception.RestApiException;
+import turing.turing.global.exception.errorCode.CommonErrorCode;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailService implements UserDetailsService {
+
+    private final TeacherRepository teacherRepository;
+    private final StudentRepository studentRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        Object member = findByEmail(email);
+
+        return new CustomUserDetails(email);
+    }
+
+    public Object findByEmail(String email) {
+        Object member = teacherRepository.findByEmail(email);
+        return Objects.requireNonNullElseGet(member, () -> studentRepository.findByEmail(email)
+                .orElseThrow(() -> new RestApiException(CommonErrorCode.NOT_FOUND)));
+    }
+}

--- a/src/main/java/turing/turing/domain/auth/CustomUserDetailService.java
+++ b/src/main/java/turing/turing/domain/auth/CustomUserDetailService.java
@@ -27,7 +27,7 @@ public class CustomUserDetailService implements UserDetailsService {
         return new CustomUserDetails(email);
     }
 
-    public Object findByEmail(String email) {
+    private Object findByEmail(String email) {
         Object member = teacherRepository.findByEmail(email);
         return Objects.requireNonNullElseGet(member, () -> studentRepository.findByEmail(email)
                 .orElseThrow(() -> new RestApiException(CommonErrorCode.NOT_FOUND)));

--- a/src/main/java/turing/turing/domain/auth/CustomUserDetailService.java
+++ b/src/main/java/turing/turing/domain/auth/CustomUserDetailService.java
@@ -1,13 +1,14 @@
 package turing.turing.domain.auth;
 
 import java.util.Objects;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import turing.turing.domain.student.StudentRepository;
+import turing.turing.domain.teacher.Teacher;
 import turing.turing.domain.teacher.TeacherRepository;
 import turing.turing.global.exception.RestApiException;
 import turing.turing.global.exception.errorCode.CommonErrorCode;
@@ -21,14 +22,14 @@ public class CustomUserDetailService implements UserDetailsService {
 
     @Override
     @Transactional(readOnly = true)
-    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+    public CustomUserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
         Object member = findByEmail(email);
 
         return new CustomUserDetails(email);
     }
 
     private Object findByEmail(String email) {
-        Object member = teacherRepository.findByEmail(email);
+        Optional<Teacher> member = teacherRepository.findByEmail(email);
         return Objects.requireNonNullElseGet(member, () -> studentRepository.findByEmail(email)
                 .orElseThrow(() -> new RestApiException(CommonErrorCode.NOT_FOUND)));
     }

--- a/src/main/java/turing/turing/domain/auth/CustomUserDetails.java
+++ b/src/main/java/turing/turing/domain/auth/CustomUserDetails.java
@@ -9,14 +9,27 @@ import org.springframework.security.oauth2.core.oidc.OidcIdToken;
 import org.springframework.security.oauth2.core.oidc.OidcUserInfo;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.security.oauth2.core.user.OAuth2User;
+import turing.turing.domain.Role;
 
 @Getter
 public class CustomUserDetails implements OAuth2User, UserDetails, OidcUser {
 
-    private final String userId;
+    private final String email;
+    private Role role;
+    private Long memberId;
 
-    public CustomUserDetails(String userId) {
-        this.userId = userId;
+    public CustomUserDetails(String email) {
+        this.email = email;
+    }
+
+    public CustomUserDetails role(Role role) {
+        this.role = role;
+        return this;
+    }
+
+    public CustomUserDetails memberId(Long memberId) {
+        this.memberId = memberId;
+        return this;
     }
 
     @Override
@@ -26,7 +39,7 @@ public class CustomUserDetails implements OAuth2User, UserDetails, OidcUser {
 
     @Override
     public String getUsername() {
-        return userId;
+        return email;
     }
 
     @Override
@@ -76,7 +89,7 @@ public class CustomUserDetails implements OAuth2User, UserDetails, OidcUser {
 
     @Override
     public String getName() {
-        return userId;
+        return email;
     }
 
 

--- a/src/main/java/turing/turing/domain/auth/CustomUserDetails.java
+++ b/src/main/java/turing/turing/domain/auth/CustomUserDetails.java
@@ -1,0 +1,83 @@
+package turing.turing.domain.auth;
+
+import java.util.Collection;
+import java.util.Map;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.core.oidc.OidcUserInfo;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+@Getter
+public class CustomUserDetails implements OAuth2User, UserDetails, OidcUser {
+
+    private final String userId;
+
+    public CustomUserDetails(String userId) {
+        this.userId = userId;
+    }
+
+    @Override
+    public String getPassword() {
+        return null;
+    }
+
+    @Override
+    public String getUsername() {
+        return userId;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+    @Override
+    public Map<String, Object> getClaims() {
+        return null;
+    }
+
+    @Override
+    public OidcUserInfo getUserInfo() {
+        return null;
+    }
+
+    @Override
+    public OidcIdToken getIdToken() {
+        return null;
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return null;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return null;
+    }
+
+    @Override
+    public String getName() {
+        return userId;
+    }
+
+
+}

--- a/src/main/java/turing/turing/domain/auth/apple/AppleClient.java
+++ b/src/main/java/turing/turing/domain/auth/apple/AppleClient.java
@@ -1,0 +1,13 @@
+package turing.turing.domain.auth.apple;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Component
+@FeignClient(name = "apple-public-key", url = "https://appleid.apple.com")
+public interface AppleClient {
+
+    @GetMapping("/auth/keys")
+    ApplePublicKeys getApplePublicKeys();
+}

--- a/src/main/java/turing/turing/domain/auth/apple/ApplePublicKey.java
+++ b/src/main/java/turing/turing/domain/auth/apple/ApplePublicKey.java
@@ -1,0 +1,40 @@
+package turing.turing.domain.auth.apple;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+public class ApplePublicKey {
+
+    private final String kty;
+    private final String kid;
+    private final String use;
+    private final String alg;
+    private final String n;
+    private final String e;
+
+    public boolean isSameAlg(final String alg) {
+        return this.alg.equals(alg);
+    }
+
+    public boolean isSameKid(final String kid) {
+        return this.kid.equals(kid);
+    }
+
+    @JsonCreator
+    public ApplePublicKey(@JsonProperty("kty") final String kty,
+            @JsonProperty("kid") final String kid,
+            @JsonProperty("use") final String use,
+            @JsonProperty("alg") final String alg,
+            @JsonProperty("n") final String n,
+            @JsonProperty("e") final String e) {
+        this.kty = kty;
+        this.kid = kid;
+        this.use = use;
+        this.alg = alg;
+        this.n = n;
+        this.e = e;
+    }
+
+}

--- a/src/main/java/turing/turing/domain/auth/apple/ApplePublicKeyGenerator.java
+++ b/src/main/java/turing/turing/domain/auth/apple/ApplePublicKeyGenerator.java
@@ -1,0 +1,43 @@
+package turing.turing.domain.auth.apple;
+
+import java.math.BigInteger;
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.PublicKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.RSAPublicKeySpec;
+import java.util.Base64;
+import java.util.Map;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ApplePublicKeyGenerator {
+
+    private static final String SIGN_ALGORITHM_HEADER = "alg";
+    private static final String KEY_ID_HEADER = "kid";
+    private static final int POSITIVE_SIGN_NUMBER = 1;
+
+    public PublicKey generate(final Map<String, String> headers, final ApplePublicKeys publicKeys) {
+        final ApplePublicKey applePublicKey = publicKeys.getMatchingKeyBy(
+                headers.get(SIGN_ALGORITHM_HEADER),
+                headers.get(KEY_ID_HEADER)
+        );
+        return generatePublicKey(applePublicKey);
+    }
+
+    private PublicKey generatePublicKey(final ApplePublicKey applePublicKey) {
+        final byte[] nBytes = Base64.getUrlDecoder().decode(applePublicKey.getN());
+        final byte[] eBytes = Base64.getUrlDecoder().decode(applePublicKey.getE());
+
+        final BigInteger n = new BigInteger(POSITIVE_SIGN_NUMBER, nBytes);
+        final BigInteger e = new BigInteger(POSITIVE_SIGN_NUMBER, eBytes);
+        final RSAPublicKeySpec rsaPublicKeySpec = new RSAPublicKeySpec(n, e);
+
+        try {
+            final KeyFactory keyFactory = KeyFactory.getInstance(applePublicKey.getKty());
+            return keyFactory.generatePublic(rsaPublicKeySpec);
+        } catch (NoSuchAlgorithmException | InvalidKeySpecException exception) {
+            throw new RuntimeException("잘못된 애플 키");
+        }
+    }
+}

--- a/src/main/java/turing/turing/domain/auth/apple/ApplePublicKeys.java
+++ b/src/main/java/turing/turing/domain/auth/apple/ApplePublicKeys.java
@@ -1,0 +1,23 @@
+package turing.turing.domain.auth.apple;
+
+import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ApplePublicKeys {
+
+    private List<ApplePublicKey> keys;
+
+    public ApplePublicKeys(List<ApplePublicKey> keys) {
+        this.keys = List.copyOf(keys);
+    }
+
+    public ApplePublicKey getMatchingKeyBy(final String alg, final String kid) {
+        return keys.stream()
+                .filter(key -> key.isSameAlg(alg) && key.isSameKid(kid))
+                .findFirst()
+                .orElseThrow(() -> new RuntimeException("잘못된 토큰 형태입니다."));
+    }
+}

--- a/src/main/java/turing/turing/domain/auth/apple/AppleTokenParser.java
+++ b/src/main/java/turing/turing/domain/auth/apple/AppleTokenParser.java
@@ -1,0 +1,53 @@
+package turing.turing.domain.auth.apple;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.UnsupportedJwtException;
+import java.security.PublicKey;
+import java.util.Base64;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class AppleTokenParser {
+
+    private static final String IDENTITY_TOKEN_VALUE_DELIMITER="\\.";
+    private static final int HEADER_INDEX = 0;
+
+    private final ObjectMapper objectMapper;
+
+    public Map<String, String> parseHeader(final String appleIdToken) {
+        try {
+            final String encodedHeader = appleIdToken.split(IDENTITY_TOKEN_VALUE_DELIMITER)[HEADER_INDEX];
+            final String decodedHeader = new String(Base64.getUrlDecoder().decode(encodedHeader));
+            return objectMapper.readValue(decodedHeader, new TypeReference<>() {});
+        } catch (JsonMappingException e) {
+            throw new RuntimeException("올바르지 않은 appleToken");
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("디코드된 헤더 Map 형태로 분류 실패");
+        }
+    }
+
+    public Claims extractClaims(final String appleIdToken, final PublicKey publicKey) {
+        try {
+            return Jwts.parser()
+                    .verifyWith(publicKey)
+                    .build()
+                    .parseSignedClaims(appleIdToken)
+                    .getPayload();
+        } catch (UnsupportedJwtException e) {
+            throw new UnsupportedJwtException("지원되지 않는 jwt 타입");
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("비어있는 jwt");
+        } catch (JwtException e) {
+            throw new JwtException("jwt 검증 오류");
+        }
+    }
+}

--- a/src/main/java/turing/turing/domain/auth/apple/VerifyAppleRequest.java
+++ b/src/main/java/turing/turing/domain/auth/apple/VerifyAppleRequest.java
@@ -1,0 +1,13 @@
+package turing.turing.domain.auth.apple;
+
+import jakarta.validation.constraints.NotEmpty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class VerifyAppleRequest {
+
+    @NotEmpty
+    private String appleIdToken;
+}

--- a/src/main/java/turing/turing/domain/auth/dto/LoginRequest.java
+++ b/src/main/java/turing/turing/domain/auth/dto/LoginRequest.java
@@ -1,0 +1,11 @@
+package turing.turing.domain.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class LoginRequest {
+
+    private String accessToken;
+}

--- a/src/main/java/turing/turing/domain/auth/dto/LoginResponse.java
+++ b/src/main/java/turing/turing/domain/auth/dto/LoginResponse.java
@@ -1,0 +1,13 @@
+package turing.turing.domain.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import turing.turing.domain.Role;
+
+@Getter
+@AllArgsConstructor
+public class LoginResponse {
+
+    private Role role;
+    private Long id;
+}

--- a/src/main/java/turing/turing/domain/auth/dto/LoginResponse.java
+++ b/src/main/java/turing/turing/domain/auth/dto/LoginResponse.java
@@ -10,4 +10,5 @@ public class LoginResponse {
 
     private Role role;
     private Long id;
+    private String name;
 }

--- a/src/main/java/turing/turing/domain/auth/dto/TokenReIssueRequest.java
+++ b/src/main/java/turing/turing/domain/auth/dto/TokenReIssueRequest.java
@@ -1,0 +1,11 @@
+package turing.turing.domain.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class TokenReIssueRequest {
+
+    private String refreshToken;
+}

--- a/src/main/java/turing/turing/domain/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/turing/turing/domain/auth/jwt/JwtTokenProvider.java
@@ -1,0 +1,109 @@
+package turing.turing.domain.auth.jwt;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import java.sql.Date;
+import javax.crypto.SecretKey;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+import turing.turing.domain.Role;
+import turing.turing.domain.auth.CustomUserDetailService;
+
+@Component
+@RequiredArgsConstructor
+public class JwtTokenProvider {
+
+    @Value("${jwt.secret}")
+    private static String SECRET_KEY;
+    @Value("${jwt.access-expiration}")
+    private static long EXPIRATION_TIME;
+    @Value("${jwt.refresh-expiration}")
+    private static long REFRESH_EXPIRATION_TIME;
+
+    private final CustomUserDetailService userDetailService;
+
+    public String createAccessToken(String email, Role role) {
+        Claims claims = Jwts.claims()
+                .add("role", role)
+                .build();
+
+        return Jwts.builder()
+                .subject(email)
+                .claims(claims)
+                .signWith(getSigningKey())
+                .expiration(new Date(System.currentTimeMillis() + EXPIRATION_TIME))
+                .compact();
+    }
+
+    //TODO Redis
+    public String createRefreshToken(String email) {
+        return Jwts.builder()
+                .subject(email)
+                .signWith(getSigningKey())
+                .expiration(new Date(System.currentTimeMillis() + REFRESH_EXPIRATION_TIME))
+                .compact();
+    }
+
+    public String getEmailFromToken(String token) {
+        try {
+            Jws<Claims> claims = Jwts.parser()
+                    .verifyWith(getSigningKey())
+                    .build()
+                    .parseSignedClaims(token);
+
+            return claims.getPayload().getSubject();
+        } catch (JwtException e) {
+            return null;
+        }
+    }
+
+    public Role getRoleFromToken(String token) {
+        try {
+            Jws<Claims> claims = Jwts.parser()
+                    .verifyWith(getSigningKey())
+                    .build()
+                    .parseSignedClaims(token);
+
+            return claims.getPayload().get("role", Role.class);
+        } catch (ExpiredJwtException e) {
+            throw new JwtException("Expired token");
+        } catch (JwtException e) {
+            throw new JwtException("Invalid token");
+        }
+    }
+
+    public boolean validationToken(String token) {
+        try {
+            Jws<Claims> claims = Jwts.parser()
+                    .verifyWith(getSigningKey())
+                    .build()
+                    .parseSignedClaims(token);
+
+            return !claims.getPayload().getExpiration().before(new Date(System.currentTimeMillis()));
+        } catch (JwtException e) {
+            return false;
+        }
+    }
+
+    public Authentication getAuthentication(String token) {
+        String email = getEmailFromToken(token);
+        UserDetails userDetails = userDetailService.loadUserByUsername(email);
+
+        return new UsernamePasswordAuthenticationToken(userDetails, "",
+                userDetails.getAuthorities());
+    }
+
+    private SecretKey getSigningKey() {
+        byte[] keyBytes = Decoders.BASE64.decode(SECRET_KEY);
+        return Keys.hmacShaKeyFor(keyBytes);
+    }
+}

--- a/src/main/java/turing/turing/domain/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/turing/turing/domain/auth/jwt/JwtTokenProvider.java
@@ -25,8 +25,9 @@ public class JwtTokenProvider {
     @Value("${jwt.refresh-expiration}")
     private static long REFRESH_EXPIRATION_TIME;
 
-    public String createAccessToken(String email, Role role) {
+    public String createAccessToken(String email, Long memberId, Role role) {
         Claims claims = Jwts.claims()
+                .add("memberId", memberId)
                 .add("role", role)
                 .build();
 
@@ -68,6 +69,21 @@ public class JwtTokenProvider {
                     .parseSignedClaims(token);
 
             return claims.getPayload().get("role", Role.class);
+        } catch (ExpiredJwtException e) {
+            throw new JwtException("Expired token");
+        } catch (JwtException e) {
+            throw new JwtException("Invalid token");
+        }
+    }
+
+    public Long getMemberIdFromToken(String token) {
+        try {
+            Jws<Claims> claims = Jwts.parser()
+                    .verifyWith(getSigningKey())
+                    .build()
+                    .parseSignedClaims(token);
+
+            return claims.getPayload().get("memberId", Long.class);
         } catch (ExpiredJwtException e) {
             throw new JwtException("Expired token");
         } catch (JwtException e) {

--- a/src/main/java/turing/turing/domain/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/turing/turing/domain/auth/jwt/JwtTokenProvider.java
@@ -11,12 +11,8 @@ import java.sql.Date;
 import javax.crypto.SecretKey;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 import turing.turing.domain.Role;
-import turing.turing.domain.auth.CustomUserDetailService;
 
 @Component
 @RequiredArgsConstructor
@@ -28,8 +24,6 @@ public class JwtTokenProvider {
     private static long EXPIRATION_TIME;
     @Value("${jwt.refresh-expiration}")
     private static long REFRESH_EXPIRATION_TIME;
-
-    private final CustomUserDetailService userDetailService;
 
     public String createAccessToken(String email, Role role) {
         Claims claims = Jwts.claims()
@@ -92,14 +86,6 @@ public class JwtTokenProvider {
         } catch (JwtException e) {
             return false;
         }
-    }
-
-    public Authentication getAuthentication(String token) {
-        String email = getEmailFromToken(token);
-        UserDetails userDetails = userDetailService.loadUserByUsername(email);
-
-        return new UsernamePasswordAuthenticationToken(userDetails, "",
-                userDetails.getAuthorities());
     }
 
     private SecretKey getSigningKey() {

--- a/src/main/java/turing/turing/domain/auth/jwt/TokenResponse.java
+++ b/src/main/java/turing/turing/domain/auth/jwt/TokenResponse.java
@@ -1,0 +1,13 @@
+package turing.turing.domain.auth.jwt;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class TokenResponse {
+
+    private String email;
+    private String accessToken;
+    private String refreshToken;
+}

--- a/src/main/java/turing/turing/domain/student/StudentRepository.java
+++ b/src/main/java/turing/turing/domain/student/StudentRepository.java
@@ -4,5 +4,6 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface StudentRepository extends JpaRepository<Student, Long> {
+
     Optional<Student> findByEmail(String email);
 }

--- a/src/main/java/turing/turing/domain/teacher/TeacherController.java
+++ b/src/main/java/turing/turing/domain/teacher/TeacherController.java
@@ -1,0 +1,36 @@
+package turing.turing.domain.teacher;
+
+import jakarta.validation.Valid;
+import java.net.URI;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+import turing.turing.domain.teacher.dto.SignUpResponse;
+import turing.turing.domain.teacher.dto.TeacherSignUpRequest;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/teacher")
+public class TeacherController {
+
+    private final TeacherService teacherService;
+
+
+    @PostMapping("/signup")
+    public ResponseEntity<SignUpResponse> signUp(@RequestBody @Valid TeacherSignUpRequest request) {
+
+        SignUpResponse response = teacherService.signUp(request);
+
+        URI location = ServletUriComponentsBuilder
+                .fromCurrentContextPath()
+                .path("/teacher/{id}")
+                .buildAndExpand(response.getId())
+                .toUri();
+
+        return ResponseEntity.created(location).body(response);
+    }
+}

--- a/src/main/java/turing/turing/domain/teacher/TeacherRepository.java
+++ b/src/main/java/turing/turing/domain/teacher/TeacherRepository.java
@@ -1,6 +1,9 @@
 package turing.turing.domain.teacher;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TeacherRepository extends JpaRepository<Teacher, Long> {
+
+    Optional<Teacher> findByEmail(String email);
 }

--- a/src/main/java/turing/turing/domain/teacher/TeacherService.java
+++ b/src/main/java/turing/turing/domain/teacher/TeacherService.java
@@ -28,7 +28,7 @@ public class TeacherService {
         Teacher teacher = new Teacher(email, request.getName(), request.getProvider());
         Teacher savedTeacher = teacherRepository.save(teacher);
 
-        String accessToken = jwtTokenProvider.createAccessToken(email, Role.TEACHER);
+        String accessToken = jwtTokenProvider.createAccessToken(email, teacher.getId(), Role.TEACHER);
         String refreshToken = jwtTokenProvider.createRefreshToken(email);
 
         return SignUpResponse.builder()

--- a/src/main/java/turing/turing/domain/teacher/TeacherService.java
+++ b/src/main/java/turing/turing/domain/teacher/TeacherService.java
@@ -1,0 +1,41 @@
+package turing.turing.domain.teacher;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import turing.turing.domain.Role;
+import turing.turing.domain.auth.jwt.JwtTokenProvider;
+import turing.turing.domain.teacher.dto.SignUpResponse;
+import turing.turing.domain.teacher.dto.TeacherSignUpRequest;
+import turing.turing.global.exception.RestApiException;
+import turing.turing.global.exception.errorCode.CommonErrorCode;
+
+@Service
+@RequiredArgsConstructor
+public class TeacherService {
+
+    private final TeacherRepository teacherRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Transactional
+    public SignUpResponse signUp(TeacherSignUpRequest request) {
+        String email = request.getEmail();
+
+        if (teacherRepository.findByEmail(email).isPresent()) {
+            throw new RestApiException(CommonErrorCode.BAD_REQUEST);
+        }
+
+        Teacher teacher = new Teacher(email, request.getName(), request.getProvider());
+        Teacher savedTeacher = teacherRepository.save(teacher);
+
+        String accessToken = jwtTokenProvider.createAccessToken(email, Role.TEACHER);
+        String refreshToken = jwtTokenProvider.createRefreshToken(email);
+
+        return SignUpResponse.builder()
+                .id(savedTeacher.getId())
+                .role(Role.TEACHER)
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+}

--- a/src/main/java/turing/turing/domain/teacher/dto/SignUpResponse.java
+++ b/src/main/java/turing/turing/domain/teacher/dto/SignUpResponse.java
@@ -1,0 +1,15 @@
+package turing.turing.domain.teacher.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import turing.turing.domain.Role;
+
+@Getter
+@Builder
+public class SignUpResponse {
+
+    private Long id;
+    private Role role;
+    private String accessToken;
+    private String refreshToken;
+}

--- a/src/main/java/turing/turing/domain/teacher/dto/TeacherSignUpRequest.java
+++ b/src/main/java/turing/turing/domain/teacher/dto/TeacherSignUpRequest.java
@@ -1,0 +1,14 @@
+package turing.turing.domain.teacher.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import turing.turing.domain.Provider;
+
+@Getter
+@AllArgsConstructor
+public class TeacherSignUpRequest {
+
+    private String email;
+    private String name;
+    private Provider provider;
+}

--- a/src/main/java/turing/turing/global/config/OpenFeignConfig.java
+++ b/src/main/java/turing/turing/global/config/OpenFeignConfig.java
@@ -1,0 +1,13 @@
+package turing.turing.global.config;
+
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.cloud.openfeign.FeignAutoConfiguration;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableFeignClients("turing.turing.domain.auth.apple")
+@ImportAutoConfiguration({FeignAutoConfiguration.class})
+public class OpenFeignConfig {
+
+}

--- a/src/main/java/turing/turing/global/config/SecurityConfig.java
+++ b/src/main/java/turing/turing/global/config/SecurityConfig.java
@@ -1,24 +1,38 @@
 package turing.turing.global.config;
 
-import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import turing.turing.domain.auth.jwt.JwtTokenProvider;
+import turing.turing.global.security.JwtAuthenticationFilter;
 
 @EnableWebSecurity
-@AllArgsConstructor
+@RequiredArgsConstructor
 @Configuration
 public class SecurityConfig {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Bean
+    public JwtAuthenticationFilter jwtAuthenticationFilter() {
+        return new JwtAuthenticationFilter(jwtTokenProvider);
+    }
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
                 .csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests((authorizeRequests) ->
-                authorizeRequests.anyRequest().permitAll());
+                        authorizeRequests.requestMatchers("/api/auth", "/teacher/signup")
+                                .permitAll()
+                                .anyRequest().authenticated())
+                .addFilterBefore(jwtAuthenticationFilter(),
+                        UsernamePasswordAuthenticationFilter.class);
         return http.build();
 
     }

--- a/src/main/java/turing/turing/global/config/SecurityConfig.java
+++ b/src/main/java/turing/turing/global/config/SecurityConfig.java
@@ -1,6 +1,5 @@
 package turing.turing.global.config;
 
-import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -8,19 +7,24 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-import turing.turing.domain.auth.jwt.JwtTokenProvider;
 import turing.turing.global.security.JwtAuthenticationFilter;
 
 @EnableWebSecurity
-@RequiredArgsConstructor
 @Configuration
 public class SecurityConfig {
 
-    private final JwtTokenProvider jwtTokenProvider;
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
-    @Bean
-    public JwtAuthenticationFilter jwtAuthenticationFilter() {
-        return new JwtAuthenticationFilter(jwtTokenProvider);
+    private static final String[] AUTH_WHITELIST = {
+            "/api/auth",
+            "/teacher/signup",
+            "/swagger-ui/**",
+            "/v3/api-docs/**",
+            "/test/exception/param"
+    };
+
+    public SecurityConfig(JwtAuthenticationFilter jwtAuthenticationFilter) {
+        this.jwtAuthenticationFilter = jwtAuthenticationFilter;
     }
 
     @Bean
@@ -28,10 +32,10 @@ public class SecurityConfig {
         http
                 .csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests((authorizeRequests) ->
-                        authorizeRequests.requestMatchers("/api/auth", "/teacher/signup")
+                        authorizeRequests.requestMatchers(AUTH_WHITELIST)
                                 .permitAll()
                                 .anyRequest().authenticated())
-                .addFilterBefore(jwtAuthenticationFilter(),
+                .addFilterBefore(jwtAuthenticationFilter,
                         UsernamePasswordAuthenticationFilter.class);
         return http.build();
 

--- a/src/main/java/turing/turing/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/turing/turing/global/security/JwtAuthenticationFilter.java
@@ -1,6 +1,5 @@
 package turing.turing.global.security;
 
-import io.jsonwebtoken.JwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -8,18 +7,24 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
+import turing.turing.domain.auth.CustomUserDetailService;
 import turing.turing.domain.auth.jwt.JwtTokenProvider;
 
 @RequiredArgsConstructor
+@Component
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
-    private final JwtTokenProvider jwtTokenProvider;
     private final static String HEADER_AUTHORIZATION = "Authorization";
     private final static String TOKEN_PREFIX = "Bearer";
 
+    private final JwtTokenProvider jwtTokenProvider;
+    private final CustomUserDetailService customUserDetailService;
 
     @Override
     protected void doFilterInternal(@NonNull HttpServletRequest request, @NonNull HttpServletResponse response,
@@ -27,11 +32,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         String token = getAccessToken(request);
         if (token != null && jwtTokenProvider.validationToken(token)) {
-            Authentication authentication = jwtTokenProvider.getAuthentication(token);
+            Authentication authentication = getAuthentication(token);
             SecurityContextHolder.getContext().setAuthentication(authentication);
-        } else {
-            throw new JwtException("토큰 유효성 검증 실패");
         }
+//        else {
+//            throw new JwtException("토큰 유효성 검증 실패");
+//        }
 
         filterChain.doFilter(request, response);
     }
@@ -39,11 +45,20 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private String getAccessToken(HttpServletRequest request) {
         String token = request.getHeader(HEADER_AUTHORIZATION);
         if (token == null) {
-            throw new NullPointerException();
+//            throw new NullPointerException();
+            return null;
         } else if (token.startsWith(TOKEN_PREFIX)) {
             return token.substring(7);
         }
 
         return null;
+    }
+
+    private Authentication getAuthentication(String token) {
+        String email = jwtTokenProvider.getEmailFromToken(token);
+        UserDetails userDetails = customUserDetailService.loadUserByUsername(email);
+
+        return new UsernamePasswordAuthenticationToken(userDetails, "",
+                userDetails.getAuthorities());
     }
 }

--- a/src/main/java/turing/turing/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/turing/turing/global/security/JwtAuthenticationFilter.java
@@ -10,10 +10,11 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
+import turing.turing.domain.Role;
 import turing.turing.domain.auth.CustomUserDetailService;
+import turing.turing.domain.auth.CustomUserDetails;
 import turing.turing.domain.auth.jwt.JwtTokenProvider;
 
 @RequiredArgsConstructor
@@ -56,7 +57,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private Authentication getAuthentication(String token) {
         String email = jwtTokenProvider.getEmailFromToken(token);
-        UserDetails userDetails = customUserDetailService.loadUserByUsername(email);
+        Role role = jwtTokenProvider.getRoleFromToken(token);
+        Long memberId = jwtTokenProvider.getMemberIdFromToken(token);
+        CustomUserDetails userDetails = customUserDetailService.loadUserByUsername(email)
+                .role(role)
+                .memberId(memberId);
 
         return new UsernamePasswordAuthenticationToken(userDetails, "",
                 userDetails.getAuthorities());

--- a/src/main/java/turing/turing/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/turing/turing/global/security/JwtAuthenticationFilter.java
@@ -1,0 +1,49 @@
+package turing.turing.global.security;
+
+import io.jsonwebtoken.JwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+import turing.turing.domain.auth.jwt.JwtTokenProvider;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final static String HEADER_AUTHORIZATION = "Authorization";
+    private final static String TOKEN_PREFIX = "Bearer";
+
+
+    @Override
+    protected void doFilterInternal(@NonNull HttpServletRequest request, @NonNull HttpServletResponse response,
+            @NonNull FilterChain filterChain) throws ServletException, IOException {
+
+        String token = getAccessToken(request);
+        if (token != null && jwtTokenProvider.validationToken(token)) {
+            Authentication authentication = jwtTokenProvider.getAuthentication(token);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        } else {
+            throw new JwtException("토큰 유효성 검증 실패");
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String getAccessToken(HttpServletRequest request) {
+        String token = request.getHeader(HEADER_AUTHORIZATION);
+        if (token == null) {
+            throw new NullPointerException();
+        } else if (token.startsWith(TOKEN_PREFIX)) {
+            return token.substring(7);
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
## 📄 Description

- close : #29 

## 📌 구현 내용
- SecurityConfig에서 설정한 검증 제외 api에 대해서도 JwtAuthenticationFilter에서 검증이 실행되어 이를 수정하였습니다. 
    - JwtAuthenticationFilter의 getAccessToken에서 http 요청에 토큰이 담겨있지 않더라도 예외처리 하지않고 null을 리턴하도록 하였습니다.
    - 리턴된 null에 대한 예외처리를 적용하지 않았습니다.
- JwtTokenProvider의 getAuthentication 메서드를 JwtAuthenticationFilter에서 구현하였습니다.
- 토큰 검증 제외 api를 메서드 내에 위치하지 않고 AUTH_WHITELIST로 분리하였습니다.