### PR TITLE
[Feat] 질문게시판 도메인 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-aop'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
 	implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.1'	//sql문 데이터값으로 확인
+	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'

--- a/src/main/java/turing/turing/domain/comment/Comment.java
+++ b/src/main/java/turing/turing/domain/comment/Comment.java
@@ -1,4 +1,4 @@
-package turing.turing.domain.answer;
+package turing.turing.domain.comment;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -18,16 +18,16 @@ import turing.turing.domain.question.Question;
 @Getter
 @Entity
 @NoArgsConstructor
-public class Answer extends BaseEntity {
+public class Comment extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "answer_id", nullable = false)
+    @Column(name = "comment_id", nullable = false)
     private Long id;
 
     @Size(max = 200)
-    @Column(name = "answer_image", length = 200)
-    private String answerImage;
+    @Column(name = "comment_image", length = 200)
+    private String commentImage;
 
     @Size(max = 300)
     @Column(name = "content", length = 300)

--- a/src/main/java/turing/turing/domain/comment/Comment.java
+++ b/src/main/java/turing/turing/domain/comment/Comment.java
@@ -10,6 +10,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import turing.turing.domain.BaseEntity;
@@ -25,12 +26,22 @@ public class Comment extends BaseEntity {
     @Column(name = "comment_id", nullable = false)
     private Long id;
 
-    @Size(max = 200)
-    @Column(name = "comment_image", length = 200)
-    private String commentImage;
+    @NotNull
+    @Size(max = 10)
+    @Column(name = "role", length = 10, nullable = false)
+    private String role;  // 추후 Enum으로 변경
 
+    @NotNull
+    @Column(name = "member_id", nullable = false)
+    private Long memberId;
+
+    @Size(max = 200)
+    @Column(name = "image_url", length = 200)
+    private String imageUrl;
+
+    @NotNull
     @Size(max = 300)
-    @Column(name = "content", length = 300)
+    @Column(name = "content", length = 300, nullable = false)
     private String content;
 
     @NotNull
@@ -38,4 +49,12 @@ public class Comment extends BaseEntity {
     @JoinColumn(name = "question_id", nullable = false)
     private Question question;
 
+    @Builder
+    public Comment(String role, Long memberId, String content, String imageUrl, Question question) {
+        this.role = role;
+        this.memberId = memberId;
+        this.imageUrl = imageUrl;
+        this.content = content;
+        this.question = question;
+    }
 }

--- a/src/main/java/turing/turing/domain/comment/CommentController.java
+++ b/src/main/java/turing/turing/domain/comment/CommentController.java
@@ -1,0 +1,43 @@
+package turing.turing.domain.comment;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+import turing.turing.domain.comment.dto.request.CommentReqDto;
+import turing.turing.domain.comment.dto.response.CommentCreateResDto;
+
+import java.net.URI;
+
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class CommentController {
+
+    private final CommentService commentService;
+
+    @PostMapping("/questions/{questionId}/comments")
+    public ResponseEntity<Long> createComment(
+            @PathVariable Long questionId,
+            @RequestPart(value = "comment") CommentReqDto commentReqDto,
+            @RequestPart(value = "file", required = false) MultipartFile file) {
+
+        // 추후 Role 가져와 선생인지 학생인지 전달 필요 !
+        CommentCreateResDto commentCreateResDto = commentService.createComment("TEACHER", questionId, commentReqDto, file);
+
+        Long commentId = commentCreateResDto.commentId();
+        URI location = URI.create("/api/comments/" + commentId);
+
+        return ResponseEntity.created(location).body(commentId);
+    }
+
+    @DeleteMapping("/comments/{commentId}")
+    public ResponseEntity<Void> deleteComment(@PathVariable Long commentId){
+
+        commentService.deleteComment(commentId);
+
+        return ResponseEntity.noContent().build();
+    }
+
+}

--- a/src/main/java/turing/turing/domain/comment/CommentRepository.java
+++ b/src/main/java/turing/turing/domain/comment/CommentRepository.java
@@ -1,0 +1,10 @@
+package turing.turing.domain.comment;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import turing.turing.domain.question.Question;
+
+import java.util.List;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+    List<Comment> findAllByQuestion(Question question);
+}

--- a/src/main/java/turing/turing/domain/comment/CommentService.java
+++ b/src/main/java/turing/turing/domain/comment/CommentService.java
@@ -1,0 +1,73 @@
+package turing.turing.domain.comment;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+import turing.turing.domain.comment.dto.request.CommentReqDto;
+import turing.turing.domain.comment.dto.response.CommentCreateResDto;
+import turing.turing.domain.question.Question;
+import turing.turing.domain.question.QuestionRepository;
+import turing.turing.global.exception.RestApiException;
+import turing.turing.global.exception.errorCode.CommonErrorCode;
+import turing.turing.global.s3.S3Service;
+
+@Slf4j
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class CommentService {
+
+    private final CommentRepository commentRepository;
+    private final QuestionRepository questionRepository;
+    private final S3Service s3Service;
+
+    @Transactional
+    public CommentCreateResDto createComment(String role, Long questionId, CommentReqDto commentReqDto, MultipartFile file) {  // Role Enum 클래스 적용 필요 !
+
+        Question question = questionRepository.findWithStudyRoomById(questionId)
+                .orElseThrow(() -> new RestApiException(CommonErrorCode.NOT_FOUND));
+
+        Long teacherId = question.getStudyRoom().getTeacher().getId();
+        Long studentId = question.getStudyRoom().getStudent().getId();
+        boolean isTeacher = (role == "TEACHER");  // 추후 Enum 변경
+
+        String fileUrl = null;
+        if(file != null && !file.isEmpty())
+            fileUrl = s3Service.uploadFile(file);  // 파일이 존재할 경우 S3에 업로드 후 URL 저장
+
+        // 댓글 생성
+        Comment comment = Comment.builder()
+                .role(role)
+                .memberId(isTeacher ? teacherId : studentId)
+                .content(commentReqDto.content())
+                .imageUrl(fileUrl)
+                .question(question)
+                .build();
+
+        Comment savedComment = commentRepository.save(comment);
+
+        // 이 부분 Role Enum 클래스 리턴하는 로직으로 변경 필요 !
+        return CommentCreateResDto.builder()
+                .commentId(savedComment.getId())
+                .senderRole(isTeacher ? "TEACHER" : "STUDENT")
+                .senderId(isTeacher ? teacherId : studentId)
+                .receiverRole(isTeacher ? "STUDENT" : "TEACHER")
+                .receiverId(isTeacher ? studentId : teacherId)
+                .questionId(questionId)
+                .build();
+    }
+
+    @Transactional
+    public void deleteComment(Long commentId){
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new RestApiException(CommonErrorCode.NOT_FOUND));
+
+        // 이미지가 존재한다면 해당 이미지를 S3에서 삭제 후 댓글 삭제
+        if(comment.getImageUrl() != null && !comment.getImageUrl().isEmpty())
+            s3Service.deleteFile(comment.getImageUrl());
+
+        commentRepository.delete(comment);
+    }
+}

--- a/src/main/java/turing/turing/domain/comment/dto/CommentResDto.java
+++ b/src/main/java/turing/turing/domain/comment/dto/CommentResDto.java
@@ -1,0 +1,17 @@
+package turing.turing.domain.comment.dto;
+
+import turing.turing.domain.comment.Comment;
+
+public record CommentResDto(
+        Long id,
+        String commentImage,
+        String content
+) {
+    public static CommentResDto of(Comment comment) {
+        return new CommentResDto(
+                comment.getId(),
+                comment.getCommentImage(),
+                comment.getContent()
+        );
+    }
+}

--- a/src/main/java/turing/turing/domain/comment/dto/request/CommentReqDto.java
+++ b/src/main/java/turing/turing/domain/comment/dto/request/CommentReqDto.java
@@ -1,0 +1,6 @@
+package turing.turing.domain.comment.dto.request;
+
+public record CommentReqDto(
+        String content
+) {
+}

--- a/src/main/java/turing/turing/domain/comment/dto/response/CommentCreateResDto.java
+++ b/src/main/java/turing/turing/domain/comment/dto/response/CommentCreateResDto.java
@@ -1,0 +1,15 @@
+package turing.turing.domain.comment.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record CommentCreateResDto(
+        Long commentId,
+        // 아래는 알림을 위해 필요한 필드
+        Long senderId,
+        String senderRole,
+        Long receiverId,
+        String receiverRole,
+        Long questionId
+) {
+}

--- a/src/main/java/turing/turing/domain/comment/dto/response/CommentResDto.java
+++ b/src/main/java/turing/turing/domain/comment/dto/response/CommentResDto.java
@@ -1,16 +1,16 @@
-package turing.turing.domain.comment.dto;
+package turing.turing.domain.comment.dto.response;
 
 import turing.turing.domain.comment.Comment;
 
 public record CommentResDto(
         Long id,
-        String commentImage,
+        String imageUrl,
         String content
 ) {
     public static CommentResDto of(Comment comment) {
         return new CommentResDto(
                 comment.getId(),
-                comment.getCommentImage(),
+                comment.getImageUrl(),
                 comment.getContent()
         );
     }

--- a/src/main/java/turing/turing/domain/question/Question.java
+++ b/src/main/java/turing/turing/domain/question/Question.java
@@ -58,4 +58,11 @@ public class Question extends BaseEntity {
     @JoinColumn(name = "study_room_id", nullable = false)
     private StudyRoom studyRoom;
 
+    public void switchPinStatus(){
+        this.pinStatus = !this.pinStatus;
+    }
+
+    public void switchSolveStatus(){
+        this.solveStatus= !this.solveStatus;
+    }
 }

--- a/src/main/java/turing/turing/domain/question/Question.java
+++ b/src/main/java/turing/turing/domain/question/Question.java
@@ -31,6 +31,11 @@ public class Question extends BaseEntity {
     @Column(name = "title", nullable = false, length = 100)
     private String title;
 
+    @Size(max = 10)
+    @NotNull
+    @Column(name = "category", nullable = false, length = 10)
+    private String category;
+
     @Size(max = 300)
     @NotNull
     @Column(name = "content", nullable = false, length = 300)

--- a/src/main/java/turing/turing/domain/question/Question.java
+++ b/src/main/java/turing/turing/domain/question/Question.java
@@ -11,6 +11,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import turing.turing.domain.BaseEntity;
@@ -57,6 +58,16 @@ public class Question extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "study_room_id", nullable = false)
     private StudyRoom studyRoom;
+
+    @Builder
+    public Question(String title, String category, String content, String questionImage, StudyRoom studyRoom) {
+        super();
+        this.title = title;
+        this.category = category;
+        this.content = content;
+        this.questionImage = questionImage;
+        this.studyRoom = studyRoom;
+    }
 
     public void switchPinStatus(){
         this.pinStatus = !this.pinStatus;

--- a/src/main/java/turing/turing/domain/question/Question.java
+++ b/src/main/java/turing/turing/domain/question/Question.java
@@ -43,8 +43,8 @@ public class Question extends BaseEntity {
     private String content;
 
     @Size(max = 200)
-    @Column(name = "question_image", length = 200)
-    private String questionImage;
+    @Column(name = "image_url", length = 200)
+    private String imageUrl;
 
     @NotNull
     @Column(name = "solve_status", nullable = false)
@@ -60,12 +60,12 @@ public class Question extends BaseEntity {
     private StudyRoom studyRoom;
 
     @Builder
-    public Question(String title, String category, String content, String questionImage, StudyRoom studyRoom) {
+    public Question(String title, String category, String content, String imageUrl, StudyRoom studyRoom) {
         super();
         this.title = title;
         this.category = category;
         this.content = content;
-        this.questionImage = questionImage;
+        this.imageUrl = imageUrl;
         this.studyRoom = studyRoom;
     }
 

--- a/src/main/java/turing/turing/domain/question/QuestionController.java
+++ b/src/main/java/turing/turing/domain/question/QuestionController.java
@@ -1,0 +1,32 @@
+package turing.turing.domain.question;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import turing.turing.domain.question.dto.response.QuestionPreviewResDto;
+import turing.turing.domain.question.dto.response.QuestionWithCommentsResDto;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/questions")
+@RequiredArgsConstructor
+public class QuestionController {
+
+    private final QuestionService questionService;
+
+    @GetMapping
+    public ResponseEntity<List<QuestionPreviewResDto>> getAllQuestions(){
+        List<QuestionPreviewResDto> questionList = questionService.getQuestionList(1L);  // 추후 Authentication 정보를 토대로 인자 전달 (role, id)
+        return ResponseEntity.ok(questionList);
+    }
+
+    @GetMapping("/{questionId}")
+    public ResponseEntity<QuestionWithCommentsResDto> getQuestion(@PathVariable(name = "questionId") Long questionId){
+        QuestionWithCommentsResDto questionWithCommentsResDto = questionService.getDetailedQuestion(questionId);
+        return ResponseEntity.ok(questionWithCommentsResDto);
+    }
+}

--- a/src/main/java/turing/turing/domain/question/QuestionController.java
+++ b/src/main/java/turing/turing/domain/question/QuestionController.java
@@ -3,39 +3,72 @@ package turing.turing.domain.question;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+import turing.turing.domain.question.dto.request.QuestionReqDto;
+import turing.turing.domain.question.dto.response.QuestionCreateResDto;
 import turing.turing.domain.question.dto.response.QuestionPreviewResDto;
 import turing.turing.domain.question.dto.response.QuestionWithCommentsResDto;
 
+import java.net.URI;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/questions")
+@RequestMapping("/api")
 @RequiredArgsConstructor
 public class QuestionController {
 
     private final QuestionService questionService;
 
-    @GetMapping
+    @GetMapping("/questions")
     public ResponseEntity<List<QuestionPreviewResDto>> getAllQuestions(){
+
         List<QuestionPreviewResDto> questionList = questionService.getQuestionList(1L);  // 추후 Authentication 정보를 토대로 인자 전달 (role, id)
+
         return ResponseEntity.ok(questionList);
     }
 
-    @GetMapping("/{questionId}")
-    public ResponseEntity<QuestionWithCommentsResDto> getQuestion(@PathVariable(name = "questionId") Long questionId){
+    @GetMapping("/questions/{questionId}")
+    public ResponseEntity<QuestionWithCommentsResDto> getQuestion(@PathVariable Long questionId){
+
         QuestionWithCommentsResDto questionWithCommentsResDto = questionService.getDetailedQuestion(questionId);
+
         return ResponseEntity.ok(questionWithCommentsResDto);
     }
 
-    @PatchMapping("/{questionId}/pin")
+    @PostMapping("/study-rooms/{studyRoomId}/questions")
+    public ResponseEntity<Long> uploadQuestion(
+            @PathVariable Long studyRoomId,
+            @RequestPart(value = "question") QuestionReqDto questionReqDto,
+            @RequestPart(value = "file", required = false) MultipartFile file) {
+
+        QuestionCreateResDto questionCreateResDto = questionService.createQuestion(studyRoomId, file, questionReqDto);
+        Long questionId = questionCreateResDto.questionId();
+        URI location = URI.create("/api/questions/" + questionId);
+
+        return ResponseEntity.created(location).body(questionId);
+    }
+
+    @DeleteMapping("/questions/{questionId}")
+    public ResponseEntity<Void> deleteQuestion(@PathVariable(name = "questionId") Long questionId){
+
+        questionService.deleteQuestion(questionId);
+
+        return ResponseEntity.noContent().build();
+    }
+
+    @PatchMapping("/questions/{questionId}/pin")
     public ResponseEntity<Void> pin(@PathVariable(name = "questionId") Long questionId) {
+
         questionService.pin(questionId);
+
         return ResponseEntity.ok().build();
     }
 
-    @PatchMapping("/{questionId}/solve")
+    @PatchMapping("/questions/{questionId}/solve")
     public ResponseEntity<Void> solve(@PathVariable(name = "questionId") Long questionId) {
+
         questionService.solve(questionId);
+
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/turing/turing/domain/question/QuestionController.java
+++ b/src/main/java/turing/turing/domain/question/QuestionController.java
@@ -41,7 +41,7 @@ public class QuestionController {
             @RequestPart(value = "question") QuestionReqDto questionReqDto,
             @RequestPart(value = "file", required = false) MultipartFile file) {
 
-        QuestionCreateResDto questionCreateResDto = questionService.createQuestion(studyRoomId, file, questionReqDto);
+        QuestionCreateResDto questionCreateResDto = questionService.createQuestion(studyRoomId, questionReqDto, file);
         Long questionId = questionCreateResDto.questionId();
         URI location = URI.create("/api/questions/" + questionId);
 

--- a/src/main/java/turing/turing/domain/question/QuestionController.java
+++ b/src/main/java/turing/turing/domain/question/QuestionController.java
@@ -2,10 +2,7 @@ package turing.turing.domain.question;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import turing.turing.domain.question.dto.response.QuestionPreviewResDto;
 import turing.turing.domain.question.dto.response.QuestionWithCommentsResDto;
 
@@ -28,5 +25,17 @@ public class QuestionController {
     public ResponseEntity<QuestionWithCommentsResDto> getQuestion(@PathVariable(name = "questionId") Long questionId){
         QuestionWithCommentsResDto questionWithCommentsResDto = questionService.getDetailedQuestion(questionId);
         return ResponseEntity.ok(questionWithCommentsResDto);
+    }
+
+    @PatchMapping("/{questionId}/pin")
+    public ResponseEntity<Void> pin(@PathVariable(name = "questionId") Long questionId) {
+        questionService.pin(questionId);
+        return ResponseEntity.ok().build();
+    }
+
+    @PatchMapping("/{questionId}/solve")
+    public ResponseEntity<Void> solve(@PathVariable(name = "questionId") Long questionId) {
+        questionService.solve(questionId);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/turing/turing/domain/question/QuestionRepository.java
+++ b/src/main/java/turing/turing/domain/question/QuestionRepository.java
@@ -1,0 +1,15 @@
+package turing.turing.domain.question;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import turing.turing.domain.teacher.Teacher;
+
+import java.util.List;
+
+public interface QuestionRepository extends JpaRepository<Question, Long> {
+
+    // 선생님용 질문 조회
+    @Query(value = "select q from Question q join q.studyRoom s where s.teacher = :teacher")
+    List<Question> findAllQuestionByTeacher(@Param(value = "teacher") Teacher teacher);
+}

--- a/src/main/java/turing/turing/domain/question/QuestionRepository.java
+++ b/src/main/java/turing/turing/domain/question/QuestionRepository.java
@@ -6,10 +6,14 @@ import org.springframework.data.repository.query.Param;
 import turing.turing.domain.teacher.Teacher;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface QuestionRepository extends JpaRepository<Question, Long> {
 
     // 선생님용 질문 조회
     @Query(value = "select q from Question q join q.studyRoom s where s.teacher = :teacher")
     List<Question> findAllQuestionByTeacher(@Param(value = "teacher") Teacher teacher);
+
+    @Query(value = "select q from Question q join fetch q.studyRoom s where q.id = :questionId")
+    Optional<Question> findWithStudyRoomById(@Param(value = "questionId") Long questionId);
 }

--- a/src/main/java/turing/turing/domain/question/QuestionService.java
+++ b/src/main/java/turing/turing/domain/question/QuestionService.java
@@ -1,19 +1,31 @@
 package turing.turing.domain.question;
 
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.ObjectMetadata;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 import turing.turing.domain.comment.Comment;
 import turing.turing.domain.comment.CommentRepository;
+import turing.turing.domain.question.dto.request.QuestionReqDto;
+import turing.turing.domain.question.dto.response.QuestionCreateResDto;
 import turing.turing.domain.question.dto.response.QuestionPreviewResDto;
 import turing.turing.domain.question.dto.response.QuestionWithCommentsResDto;
+import turing.turing.domain.student.StudentRepository;
+import turing.turing.domain.studyRoom.StudyRoom;
+import turing.turing.domain.studyRoom.StudyRoomRepository;
 import turing.turing.domain.teacher.Teacher;
 import turing.turing.domain.teacher.TeacherRepository;
 import turing.turing.global.exception.RestApiException;
 import turing.turing.global.exception.errorCode.CommonErrorCode;
+import turing.turing.global.s3.S3Service;
 
 import java.util.List;
 
+@Slf4j
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
@@ -21,7 +33,12 @@ public class QuestionService {
 
     private final TeacherRepository teacherRepository;
     private final QuestionRepository questionRepository;
+    private final StudyRoomRepository studyRoomRepository;
     private final CommentRepository commentRepository;
+    private final S3Service s3Service;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
 
     public List<QuestionPreviewResDto> getQuestionList(Long memberId){
         // 선생 학생 구분 필요 (쿼리 때문에 - teacherId? studentId?) -> Authentication을 통해 추후 구분하여 로직 작성
@@ -41,6 +58,46 @@ public class QuestionService {
         List<Comment> commentList = commentRepository.findAllByQuestion(question);
 
         return QuestionWithCommentsResDto.of(question, commentList);
+    }
+
+    @Transactional
+    public QuestionCreateResDto createQuestion(Long studyRoomId, MultipartFile file, QuestionReqDto questionReqDto){
+        StudyRoom studyRoom = studyRoomRepository.findById(studyRoomId)
+                .orElseThrow(() -> new RestApiException(CommonErrorCode.NOT_FOUND));
+
+        String fileUrl = null;
+        if(file != null && !file.isEmpty())
+            fileUrl = s3Service.uploadFile(file);  // 파일이 존재할 경우 S3에 업로드 후 URL 저장
+
+        Question question = Question.builder()
+                .title(questionReqDto.title())
+                .category(questionReqDto.category())
+                .content(questionReqDto.content())
+                .questionImage(fileUrl)
+                .studyRoom(studyRoom)
+                .build();
+
+        questionRepository.save(question);
+
+        return QuestionCreateResDto.builder()
+                .questionId(question.getId())
+                .senderId(studyRoom.getStudent().getId())
+                .senderRole("STUDENT")  // 추후 Role로 변경
+                .receiverId(studyRoom.getTeacher().getId())
+                .receiverRole("TEACHER")  // 추후 Role로 변경
+                .build();
+    }
+
+    @Transactional
+    public void deleteQuestion(Long questionId){
+        Question question = questionRepository.findById(questionId)
+                .orElseThrow(() -> new RestApiException(CommonErrorCode.NOT_FOUND));
+
+        // 이미지가 존재한다면 해당 이미지를 S3에서 삭제 후 질문 삭제
+        if(question.getQuestionImage() != null && !question.getQuestionImage().isEmpty()){
+            s3Service.deleteFile(question.getQuestionImage());
+        }
+        questionRepository.delete(question);
     }
 
     @Transactional

--- a/src/main/java/turing/turing/domain/question/QuestionService.java
+++ b/src/main/java/turing/turing/domain/question/QuestionService.java
@@ -1,0 +1,46 @@
+package turing.turing.domain.question;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import turing.turing.domain.comment.Comment;
+import turing.turing.domain.comment.CommentRepository;
+import turing.turing.domain.question.dto.response.QuestionPreviewResDto;
+import turing.turing.domain.question.dto.response.QuestionWithCommentsResDto;
+import turing.turing.domain.teacher.Teacher;
+import turing.turing.domain.teacher.TeacherRepository;
+import turing.turing.global.exception.RestApiException;
+import turing.turing.global.exception.errorCode.CommonErrorCode;
+
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class QuestionService {
+
+    private final TeacherRepository teacherRepository;
+    private final QuestionRepository questionRepository;
+    private final CommentRepository commentRepository;
+
+    public List<QuestionPreviewResDto> getQuestionList(Long memberId){
+        // 선생 학생 구분 필요 (쿼리 때문에 - teacherId? studentId?) -> Authentication을 통해 추후 구분하여 로직 작성
+
+        Teacher teacher = teacherRepository.findById(memberId)
+                .orElseThrow(() -> new RestApiException(CommonErrorCode.NOT_FOUND));
+
+
+        List<Question> questionList = questionRepository.findAllQuestionByTeacher(teacher);
+        List<QuestionPreviewResDto> questionDtoList = questionList.stream().map(QuestionPreviewResDto::of).toList();
+        return questionDtoList;
+    }
+
+    public QuestionWithCommentsResDto getDetailedQuestion(Long questionId){
+        Question question = questionRepository.findById(questionId)
+                .orElseThrow(() -> new RestApiException(CommonErrorCode.NOT_FOUND));
+        List<Comment> commentList = commentRepository.findAllByQuestion(question);
+
+        return QuestionWithCommentsResDto.of(question, commentList);
+    }
+
+}

--- a/src/main/java/turing/turing/domain/question/QuestionService.java
+++ b/src/main/java/turing/turing/domain/question/QuestionService.java
@@ -61,7 +61,7 @@ public class QuestionService {
     }
 
     @Transactional
-    public QuestionCreateResDto createQuestion(Long studyRoomId, MultipartFile file, QuestionReqDto questionReqDto){
+    public QuestionCreateResDto createQuestion(Long studyRoomId, QuestionReqDto questionReqDto, MultipartFile file){
         StudyRoom studyRoom = studyRoomRepository.findById(studyRoomId)
                 .orElseThrow(() -> new RestApiException(CommonErrorCode.NOT_FOUND));
 
@@ -73,7 +73,7 @@ public class QuestionService {
                 .title(questionReqDto.title())
                 .category(questionReqDto.category())
                 .content(questionReqDto.content())
-                .questionImage(fileUrl)
+                .imageUrl(fileUrl)
                 .studyRoom(studyRoom)
                 .build();
 
@@ -94,8 +94,8 @@ public class QuestionService {
                 .orElseThrow(() -> new RestApiException(CommonErrorCode.NOT_FOUND));
 
         // 이미지가 존재한다면 해당 이미지를 S3에서 삭제 후 질문 삭제
-        if(question.getQuestionImage() != null && !question.getQuestionImage().isEmpty()){
-            s3Service.deleteFile(question.getQuestionImage());
+        if(question.getImageUrl() != null && !question.getImageUrl().isEmpty()){
+            s3Service.deleteFile(question.getImageUrl());
         }
         questionRepository.delete(question);
     }

--- a/src/main/java/turing/turing/domain/question/QuestionService.java
+++ b/src/main/java/turing/turing/domain/question/QuestionService.java
@@ -43,4 +43,20 @@ public class QuestionService {
         return QuestionWithCommentsResDto.of(question, commentList);
     }
 
+    @Transactional
+    public void pin(Long questionId){
+        Question question = questionRepository.findById(questionId)
+                .orElseThrow(() -> new RestApiException(CommonErrorCode.NOT_FOUND));
+
+        question.switchPinStatus();
+    }
+
+    @Transactional
+    public void solve(Long questionId){
+        Question question = questionRepository.findById(questionId)
+                .orElseThrow(() -> new RestApiException(CommonErrorCode.NOT_FOUND));
+
+        question.switchSolveStatus();
+    }
+
 }

--- a/src/main/java/turing/turing/domain/question/dto/request/QuestionReqDto.java
+++ b/src/main/java/turing/turing/domain/question/dto/request/QuestionReqDto.java
@@ -1,0 +1,8 @@
+package turing.turing.domain.question.dto.request;
+
+public record QuestionReqDto(
+        String title,
+        String category,
+        String content
+) {
+}

--- a/src/main/java/turing/turing/domain/question/dto/response/QuestionCreateResDto.java
+++ b/src/main/java/turing/turing/domain/question/dto/response/QuestionCreateResDto.java
@@ -1,0 +1,15 @@
+package turing.turing.domain.question.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record QuestionCreateResDto(
+        Long questionId,
+        // 아래는 알림을 위해 필요한 필드
+        Long senderId,
+        String senderRole,
+        Long receiverId,
+        String receiverRole,
+        String category
+) {
+}

--- a/src/main/java/turing/turing/domain/question/dto/response/QuestionPreviewResDto.java
+++ b/src/main/java/turing/turing/domain/question/dto/response/QuestionPreviewResDto.java
@@ -1,0 +1,27 @@
+package turing.turing.domain.question.dto.response;
+
+import turing.turing.domain.question.Question;
+
+import java.sql.Timestamp;
+
+public record QuestionPreviewResDto(
+        Long id,
+        String category,
+        String title,
+        String content,
+        Boolean solveStatus,
+        Boolean pinStatus,
+        Timestamp createdAt
+) {
+    public static QuestionPreviewResDto of(Question question){
+        return new QuestionPreviewResDto(
+                question.getId(),
+                question.getCategory(),
+                question.getTitle(),
+                question.getContent(),
+                question.getSolveStatus(),
+                question.getPinStatus(),
+                question.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/turing/turing/domain/question/dto/response/QuestionWithCommentsResDto.java
+++ b/src/main/java/turing/turing/domain/question/dto/response/QuestionWithCommentsResDto.java
@@ -1,0 +1,31 @@
+package turing.turing.domain.question.dto.response;
+
+import turing.turing.domain.comment.Comment;
+import turing.turing.domain.comment.dto.CommentResDto;
+import turing.turing.domain.question.Question;
+
+import java.util.List;
+
+public record QuestionWithCommentsResDto(
+        Long id,
+        String title,
+        String category,
+        String content,
+        String questionImage,
+        Boolean solveStatus,
+        Boolean pinStatus,
+        List<CommentResDto> commentList
+) {
+    public static QuestionWithCommentsResDto of(Question question, List<Comment> commentList){
+        return new QuestionWithCommentsResDto(
+                question.getId(),
+                question.getTitle(),
+                question.getCategory(),
+                question.getContent(),
+                question.getQuestionImage(),
+                question.getSolveStatus(),
+                question.getPinStatus(),
+                commentList.stream().map(CommentResDto::of).toList()
+        );
+    }
+}

--- a/src/main/java/turing/turing/domain/question/dto/response/QuestionWithCommentsResDto.java
+++ b/src/main/java/turing/turing/domain/question/dto/response/QuestionWithCommentsResDto.java
@@ -1,7 +1,7 @@
 package turing.turing.domain.question.dto.response;
 
 import turing.turing.domain.comment.Comment;
-import turing.turing.domain.comment.dto.CommentResDto;
+import turing.turing.domain.comment.dto.response.CommentResDto;
 import turing.turing.domain.question.Question;
 
 import java.util.List;
@@ -11,7 +11,7 @@ public record QuestionWithCommentsResDto(
         String title,
         String category,
         String content,
-        String questionImage,
+        String imageUrl,
         Boolean solveStatus,
         Boolean pinStatus,
         List<CommentResDto> commentList
@@ -22,7 +22,7 @@ public record QuestionWithCommentsResDto(
                 question.getTitle(),
                 question.getCategory(),
                 question.getContent(),
-                question.getQuestionImage(),
+                question.getImageUrl(),
                 question.getSolveStatus(),
                 question.getPinStatus(),
                 commentList.stream().map(CommentResDto::of).toList()

--- a/src/main/java/turing/turing/domain/student/StudentRepository.java
+++ b/src/main/java/turing/turing/domain/student/StudentRepository.java
@@ -1,0 +1,6 @@
+package turing.turing.domain.student;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StudentRepository extends JpaRepository<Student, Long> {
+}

--- a/src/main/java/turing/turing/domain/studyRoom/StudyRoomRepository.java
+++ b/src/main/java/turing/turing/domain/studyRoom/StudyRoomRepository.java
@@ -1,0 +1,7 @@
+package turing.turing.domain.studyRoom;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StudyRoomRepository extends JpaRepository<StudyRoom, Long> {
+
+}

--- a/src/main/java/turing/turing/domain/teacher/TeacherRepository.java
+++ b/src/main/java/turing/turing/domain/teacher/TeacherRepository.java
@@ -1,0 +1,6 @@
+package turing.turing.domain.teacher;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TeacherRepository extends JpaRepository<Teacher, Long> {
+}

--- a/src/main/java/turing/turing/global/config/S3Config.java
+++ b/src/main/java/turing/turing/global/config/S3Config.java
@@ -1,0 +1,28 @@
+package turing.turing.global.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+   @Value("${cloud.aws.credentials.access-key}")
+   private String accessKey;
+   @Value("${cloud.aws.credentials.secret-key}")
+   private String secretKey;
+   @Value("${cloud.aws.region.static}")
+   private String region;
+
+   @Bean
+   public AmazonS3Client amazonS3Client() {
+      BasicAWSCredentials awsCredentials = new BasicAWSCredentials(accessKey, secretKey);
+      return (AmazonS3Client) AmazonS3ClientBuilder.standard()
+              .withRegion(region)
+              .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+              .build();
+   }
+}

--- a/src/main/java/turing/turing/global/s3/FileService.java
+++ b/src/main/java/turing/turing/global/s3/FileService.java
@@ -1,0 +1,16 @@
+package turing.turing.global.s3;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public interface FileService {
+
+    //파일 업로드
+    String uploadFile(MultipartFile file);
+
+    //파일 삭제
+    void deleteFile(String fileUrl);
+
+    //파일 URL 조회
+    String getFileUrl(String fileName);
+
+}

--- a/src/main/java/turing/turing/global/s3/S3Component.java
+++ b/src/main/java/turing/turing/global/s3/S3Component.java
@@ -1,0 +1,14 @@
+package turing.turing.global.s3;
+
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+@Getter
+public class S3Component {
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+}

--- a/src/main/java/turing/turing/global/s3/S3Service.java
+++ b/src/main/java/turing/turing/global/s3/S3Service.java
@@ -1,0 +1,76 @@
+package turing.turing.global.s3;
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+import turing.turing.global.exception.RestApiException;
+import turing.turing.global.exception.errorCode.CommonErrorCode;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.UUID;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class S3Service implements FileService{
+
+    private final S3Component s3Component;
+    private final AmazonS3Client amazonS3Client;
+
+    @Override
+    public String uploadFile(MultipartFile file) {
+
+        // 파일 이름 생성
+        String fileName = createFileName(file.getOriginalFilename());
+
+        // 파일 변환
+        ObjectMetadata objectMetadata = new ObjectMetadata();
+        objectMetadata.setContentType(file.getContentType());
+        objectMetadata.setContentLength(file.getSize());
+
+        // 파일 업로드
+        try(InputStream inputStream = file.getInputStream()) {
+            amazonS3Client.putObject(s3Component.getBucket(), fileName, inputStream, objectMetadata);
+            log.info("File successfully uploaded: {}", fileName);
+        } catch (IOException e) {
+            log.error("Error uploading file: " + fileName, e);
+            throw new RestApiException(CommonErrorCode.INTERNAL_SERVER_ERROR);
+        }
+
+        return getFileUrl(fileName);
+    }
+
+    @Override
+    public void deleteFile(String fileUrl) {
+
+        String fileName = fileUrl.substring(fileUrl.lastIndexOf("/") + 1);
+
+        // 파일 삭제
+        amazonS3Client.deleteObject(s3Component.getBucket(), fileName);
+        log.info("File successfully deleted: {}", fileName);
+    }
+
+    @Override
+    public String getFileUrl(String fileName) {
+
+        return amazonS3Client.getUrl(s3Component.getBucket(), fileName).toString();
+    }
+
+    // UUID를 활용해 파일 이름 랜덤 생성
+    private String createFileName(String originalFileName) {
+        return UUID.randomUUID().toString().concat(getFileExtension(originalFileName));
+    }
+
+    // 파일의 확장자를 가져옴
+    private String getFileExtension(String fileName){
+        try{
+            return fileName.substring(fileName.lastIndexOf("."));
+        } catch(StringIndexOutOfBoundsException e) {
+            throw new IllegalArgumentException(String.format("잘못된 형식의 파일 (%s) 입니다.", fileName));
+        }
+    }
+}


### PR DESCRIPTION
## 📄 Description

- close : #13 

> 질문게시판 도메인의 질문과 댓글 관련 기능을 구현함

## 📌 구현 내용

- [x] Question 엔티티에 유형(category) 필드 추가
- [x] [질문게시판] 질문 생성 (학생용, 사진 첨부 가능)
- [x] [질문게시판] 질문 조회
- [x] [질문게시판] 질문 상세 조회 & 댓글 조회
- [x] [질문게시판] 질문 삭제 - 학생 부분 아직
- [ ] [질문게시판] 질문 수정
- [x] [질문게시판] 고정하기
- [x] [질문게시판] 질문 해결
- [x] [질문게시판] 댓글 생성 (사진 첨부 가능)
- [x] [질문게시판] 댓글 삭제

## ✅ PR 포인트

- ERD 수정에 따라 Comment 엔티티에 memberId, role 필드 추가하였습니다.
- questionImage -> imageUrl, commentImage -> imageUrl로 필드명 변경하였습니다. (사유 1: 엔티티명 중복 등장, 사유 2: url임을 나타내기 위함)
- 범준님 코드 보고 빌더 패턴의 장점에 대해 이해하고, 엔티티 생성자와 DTO에 `@Builder` 적용해 사용해보았습니다.
- 생성된 리소스에 대해 접근할 수 있는 URI 생성해 **201 Created** 응답하도록 하였습니다.
- 삭제나 업데이트 후 Body가 필요 없는 경우 **204 No Content** 응답이 사용된다는 것을 알고 해당 사항도 적용해보았습니다.
- DTO가 많으면 dto 패키지 내부가 생각보다 복잡해지기 때문에, request, response 패키지 생성해 분리하여 관리하였습니다.