### PR TITLE
[!Hotfix] 선생님과 학생의 '이름'을 '성' /' 이름' 필드 2개로 분리

### DIFF
--- a/src/main/java/turing/turing/domain/auth/AuthService.java
+++ b/src/main/java/turing/turing/domain/auth/AuthService.java
@@ -77,11 +77,11 @@ public class AuthService {
         if (role.equals(Role.TEACHER)) {
             Teacher teacher = teacherRepository.findByEmail(email)
                     .orElseThrow(() -> new RestApiException(CommonErrorCode.NOT_FOUND));
-            return new LoginResponse(role, teacher.getId(), teacher.getName(), teacher.getUniversity(), teacher.getDepartment(), teacher.getStudentNumber());
+            return new LoginResponse(role, teacher.getId(), teacher.getFirstName(), teacher.getLastName(), teacher.getUniversity(), teacher.getDepartment(), teacher.getStudentNumber());
         } else {
             Student student = studentRepository.findByEmail(email)
                     .orElseThrow(() -> new RestApiException(CommonErrorCode.NOT_FOUND));
-            return new LoginResponse(role, student.getId(), student.getName(), null, null, null);
+            return new LoginResponse(role, student.getId(), student.getFirstName(), student.getLastName(), null, null, null);
         }
     }
 

--- a/src/main/java/turing/turing/domain/auth/dto/LoginResponse.java
+++ b/src/main/java/turing/turing/domain/auth/dto/LoginResponse.java
@@ -10,7 +10,8 @@ public class LoginResponse {
 
     private Role role;
     private Long memberId;
-    private String name;
+    private String firstName;
+    private String lastName;
     private String university;
     private String department;
     private String studentNumber;

--- a/src/main/java/turing/turing/domain/member/MemberService.java
+++ b/src/main/java/turing/turing/domain/member/MemberService.java
@@ -28,7 +28,8 @@ public class MemberService {
         String email = request.getEmail();
         Role role = request.getRole();
         Provider provider = request.getProvider();
-        String name = request.getName();
+        String firstName = request.getFirstName();
+        String lastName = request.getLastName();
 
         Long memberId;
 
@@ -36,7 +37,7 @@ public class MemberService {
             teacherRepository.findByEmailAndProvider(email, provider)
                     .ifPresent((teacher) -> { throw new RestApiException(CommonErrorCode.BAD_REQUEST); });
 
-            Teacher teacher = new Teacher(email, role, provider, name);
+            Teacher teacher = new Teacher(email, role, provider, firstName, lastName);
             teacherRepository.save(teacher);
 
             memberId = teacher.getId();
@@ -44,7 +45,7 @@ public class MemberService {
             studentRepository.findByEmailAndProvider(email, provider)
                     .ifPresent((student) -> { throw new RestApiException(CommonErrorCode.BAD_REQUEST); });
 
-            Student student = new Student(email, role, provider, name);
+            Student student = new Student(email, role, provider, firstName, lastName);
             studentRepository.save(student);
 
             memberId = student.getId();

--- a/src/main/java/turing/turing/domain/member/dto/SignUpRequest.java
+++ b/src/main/java/turing/turing/domain/member/dto/SignUpRequest.java
@@ -9,6 +9,7 @@ public class SignUpRequest {
 
     private String email;
     private Role role;
-    private String name;
+    private String firstName;
+    private String lastName;
     private Provider provider;
 }

--- a/src/main/java/turing/turing/domain/notebook/NotebookRepository.java
+++ b/src/main/java/turing/turing/domain/notebook/NotebookRepository.java
@@ -40,14 +40,14 @@ public interface NotebookRepository extends JpaRepository<Notebook, Long> {
     List<Notebook> findAllByStudyRoomId(@Param("studyRoomId") Long studyRoomId, @Param("notebookId") Long notebookId, Pageable pageable);
 
     @Query(value = "SELECT st.student_id AS id, " +
-            "sc.student_name AS name, sc.subject AS subject, " +
+            "sc.student_first_name AS firstName, sc.student_last_name AS lastName, sc.subject AS subject, " +
             "IFNULL((COUNT(CASE WHEN h.is_done = 1 THEN 1 END) * 100.0 / COUNT(*)), 0) AS completionPercent " +
             "FROM study_room st " +
             "JOIN Schedule sc ON st.study_room_id = sc.study_room_id " +
             "JOIN Notebook n ON sc.schedule_id = n.schedule_id " +
             "JOIN Homework h ON n.notebook_id = h.notebook_id " +
             "WHERE st.teacher_id = :teacherId " +
-            "GROUP BY st.student_id, sc.student_name, sc.subject",
+            "GROUP BY st.student_id, sc.student_first_name, sc.student_last_name, sc.subject",
             nativeQuery = true)
     List<HomeworkPercentAllDto> getPercentByTeacherId(@Param("teacherId") Long id);
 

--- a/src/main/java/turing/turing/domain/notebook/NotebookService.java
+++ b/src/main/java/turing/turing/domain/notebook/NotebookService.java
@@ -53,7 +53,8 @@ public class NotebookService {
 
         NotebookInfo notebookInfo = NotebookInfo.builder()
                 .notebookId(notebookId)
-                .studentName(schedule.getStudentName())
+                .studentFirstName(schedule.getStudentFirstName())
+                .studentLastName(schedule.getStudentLastName())
                 .subject(schedule.getSubject())
                 .deadline(notebook.getDeadline())
                 .isDone(isDone)
@@ -162,7 +163,8 @@ public class NotebookService {
 
             NotebookInfo notebookInfo = NotebookInfo.builder()
                     .notebookId(notebook.getId())
-                    .studentName(notebook.getSchedule().getStudentName())
+                    .studentFirstName(notebook.getSchedule().getStudentFirstName())
+                    .studentLastName(notebook.getSchedule().getStudentLastName())
                     .subject(notebook.getSchedule().getSubject())
                     .deadline(notebook.getDeadline())
                     .isDone(isDone)

--- a/src/main/java/turing/turing/domain/notebook/dto/NotebookInfo.java
+++ b/src/main/java/turing/turing/domain/notebook/dto/NotebookInfo.java
@@ -11,7 +11,8 @@ import turing.turing.domain.homework.dto.HomeworkDto;
 public class NotebookInfo {
 
     private Long notebookId;
-    private String studentName;
+    private String studentFirstName;
+    private String studentLastName;
     private String subject;
     private Timestamp deadline;
     private Boolean isDone;

--- a/src/main/java/turing/turing/domain/schedule/Schedule.java
+++ b/src/main/java/turing/turing/domain/schedule/Schedule.java
@@ -47,8 +47,13 @@ public class Schedule extends BaseEntity {
 
     @Size(max = 100)
     @NotNull
-    @Column(name = "student_name", nullable = false, length = 100)
-    private String studentName;
+    @Column(name = "student_first_name", nullable = false, length = 100)
+    private String studentFirstName;
+
+    @Size(max = 100)
+    @NotNull
+    @Column(name = "student_last_name", nullable = false, length = 100)
+    private String studentLastName;
 
     @Size(max = 50)
     @NotNull

--- a/src/main/java/turing/turing/domain/student/Student.java
+++ b/src/main/java/turing/turing/domain/student/Student.java
@@ -27,8 +27,13 @@ public class Student extends Member {
 
     @Size(max = 100)
     @NotNull
-    @Column(name = "name", nullable = false, length = 100)
-    private String name;
+    @Column(name = "first_name", nullable = false, length = 100)
+    private String firstName;
+
+    @Size(max = 100)
+    @NotNull
+    @Column(name = "last_name", nullable = false, length = 100)
+    private String lastName;
 
     @Size(max = 100)
     @Column(name = "school", length = 100)
@@ -52,16 +57,18 @@ public class Student extends Member {
 
     // 학생 가입용
     @Builder
-    public Student(String email, Role role, Provider provider, String name) {
+    public Student(String email, Role role, Provider provider, String firstName, String lastName) {
         super(role, email, provider, null);  //TODO fcmToken!!!
-        this.name = name;
+        this.firstName = firstName;
+        this.lastName = lastName;
     }
 
     // 선생님 학생 등록용
     @Builder
-    public Student(String name, String school, String year, String phone, String parentPhone) {
+    public Student(String firstName, String lastName, String school, String year, String phone, String parentPhone) {
         super(Role.STUDENT, null, null, null);
-        this.name = name;
+        this.firstName = firstName;
+        this.lastName = lastName;
         this.school = school;
         this.year = year;
         this.phone = phone;

--- a/src/main/java/turing/turing/domain/studyRoom/StudyRoomService.java
+++ b/src/main/java/turing/turing/domain/studyRoom/StudyRoomService.java
@@ -130,7 +130,8 @@ public class StudyRoomService {
 
         // 기존 학생의 정보를 통해 nonSignedUpStudent 생성
         Student nonSignUpStudent = new Student(
-                studyRoom.getStudent().getName(),
+                studyRoom.getStudent().getFirstName(),
+                studyRoom.getStudent().getLastName(),
                 studyRoom.getStudent().getSchool(),
                 studyRoom.getStudent().getYear(),
                 studyRoom.getStudent().getPhone(),

--- a/src/main/java/turing/turing/domain/studyRoom/dto/DetailedStudyRoomResDto.java
+++ b/src/main/java/turing/turing/domain/studyRoom/dto/DetailedStudyRoomResDto.java
@@ -10,7 +10,8 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 public record DetailedStudyRoomResDto(
-        String studentName,
+        String studentFirstName,
+        String studentLastName,
         String subject,
         String studentSchool,
         String studentYear,
@@ -45,7 +46,8 @@ public record DetailedStudyRoomResDto(
         Integer totalBaseSession = (schedule == null ? 0: schedules.size());
 
         return new DetailedStudyRoomResDto(
-                studyRoom.getStudent().getName(),
+                studyRoom.getStudent().getFirstName(),
+                studyRoom.getStudent().getLastName(),
                 studyRoom.getSubject(),
                 studyRoom.getStudent().getSchool(),
                 studyRoom.getStudent().getYear(),

--- a/src/main/java/turing/turing/domain/studyRoom/dto/StudyRoomCreateReqDto.java
+++ b/src/main/java/turing/turing/domain/studyRoom/dto/StudyRoomCreateReqDto.java
@@ -10,7 +10,8 @@ import java.time.LocalDate;
 import java.util.List;
 
 public record StudyRoomCreateReqDto(
-        String studentName,
+        String studentFirstName,
+        String studentLastName,
         String studentSchool,
         String studentYear,
         String subject,
@@ -21,7 +22,7 @@ public record StudyRoomCreateReqDto(
         LocalDate startDate
 ) {
         public Student toStudent(){
-                return new Student(studentName, studentSchool, studentYear, null, null);
+                return new Student(studentFirstName, studentLastName, studentSchool, studentYear, null, null);
         }
 
         public StudyRoom toStudyRoom(Teacher teacher, Student student) {

--- a/src/main/java/turing/turing/domain/studyRoom/dto/StudyRoomResDto.java
+++ b/src/main/java/turing/turing/domain/studyRoom/dto/StudyRoomResDto.java
@@ -4,14 +4,16 @@ import turing.turing.domain.studyRoom.StudyRoom;
 
 public record StudyRoomResDto(
         Long id,
-        String studentName,
+        String studentFirstName,
+        String studentLastName,
         String subject,
         Boolean linkStatus
 ) {
     public static StudyRoomResDto of(StudyRoom studyRoom) {
         return new StudyRoomResDto(
                 studyRoom.getId(),
-                studyRoom.getStudent().getName(),
+                studyRoom.getStudent().getFirstName(),
+                studyRoom.getStudent().getLastName(),
                 studyRoom.getSubject(),
                 studyRoom.getLinkStatus()
         );

--- a/src/main/java/turing/turing/domain/teacher/Teacher.java
+++ b/src/main/java/turing/turing/domain/teacher/Teacher.java
@@ -26,8 +26,13 @@ public class Teacher extends Member {
 
     @Size(max = 100)
     @NotNull
-    @Column(name = "name", nullable = false, length = 100)
-    private String name;
+    @Column(name = "first_name", nullable = false, length = 100)
+    private String firstName;
+
+    @Size(max = 100)
+    @NotNull
+    @Column(name = "last_name", nullable = false, length = 100)
+    private String lastName;
 
     @Size(max = 100)
     @Column(name = "university", length = 100)
@@ -49,8 +54,9 @@ public class Teacher extends Member {
     @Column(name = "student_number")
     private String studentNumber;
 
-    public Teacher(String email, Role role, Provider provider, String name) {
+    public Teacher(String email, Role role, Provider provider, String firstName, String lastName) {
         super(role, email, provider, null);  //TODO fcmToken!!!
-        this.name = name;
+        this.firstName = firstName;
+        this.lastName = lastName;
     }
 }


### PR DESCRIPTION
## 📄 Description

- close : #46 

> 선생님과 학생의 이름을 '성' /' 이름' 필드 2개로 분리합니다.

## 📌 구현 내용

- [x] 선생님과 학생의 이름 필드 -> '성' / '이름'으로 분리
- [x] 필드 변경에 따른 로직 수정