### PR TITLE
[Feat] 과외 공간 도메인 API 수정 및 @AuthenticationPrincipal 적용

### DIFF
--- a/src/main/java/turing/turing/domain/code/ConnectionCodeRepository.java
+++ b/src/main/java/turing/turing/domain/code/ConnectionCodeRepository.java
@@ -19,5 +19,9 @@ public interface ConnectionCodeRepository extends JpaRepository<ConnectionCode, 
             "where c.code = :code")
     Optional<ConnectionCode> findWithStudyRoomAndStudentByCode(@Param(value = "code") Integer code);
 
-
+    @Query("select c from ConnectionCode c " +
+            "join fetch c.studyRoom sr " +
+            "join fetch sr.teacher t " +
+            "where c.code = :code")
+    Optional<ConnectionCode> findWithStudyRoomAndTeacherByCode(@Param(value = "code") Integer code);
 }

--- a/src/main/java/turing/turing/domain/studyRoom/StudyRoom.java
+++ b/src/main/java/turing/turing/domain/studyRoom/StudyRoom.java
@@ -92,8 +92,9 @@ public class StudyRoom extends BaseEntity {
         this.linkStatus = false;
     }
 
-    public void updateStudyRoom(String subject, Integer baseSession){
+    public void updateStudyRoom(String subject, Integer baseSession, Integer wage){
         this.subject = subject;
         this.baseSession = baseSession;
+        this.wage = wage;
     }
 }

--- a/src/main/java/turing/turing/domain/studyRoom/StudyRoomController.java
+++ b/src/main/java/turing/turing/domain/studyRoom/StudyRoomController.java
@@ -4,7 +4,11 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import turing.turing.domain.auth.CustomUserDetails;
+import turing.turing.domain.member.Role;
 import turing.turing.domain.studyRoom.dto.response.DetailedStudyRoomResDto;
 import turing.turing.domain.studyRoom.dto.request.StudyRoomCreateReqDto;
 import turing.turing.domain.studyRoom.dto.response.StudyRoomResDto;
@@ -21,22 +25,22 @@ public class StudyRoomController {
 
     private final StudyRoomService studyRoomService;
 
-    // 선생님 ID 필요
-    @Operation(summary = "과외 정보 등록")
+    @Operation(summary = "[선생님] 과외 정보 등록")
     @PostMapping
-    public ResponseEntity<Long> createStudyRoom(@RequestBody StudyRoomCreateReqDto studyRoomCreateReqDto){
-        Long studyRoomId = studyRoomService.createStudyRoom(1L, studyRoomCreateReqDto);
+    public ResponseEntity<Long> createStudyRoom(@AuthenticationPrincipal CustomUserDetails user, @RequestBody StudyRoomCreateReqDto studyRoomCreateReqDto){
+        Long teacherId = user.getMemberId();
+        Long studyRoomId = studyRoomService.createStudyRoom(teacherId, studyRoomCreateReqDto);
         return ResponseEntity.ok(studyRoomId);
     }
 
-    @Operation(summary = "과외 정보 수정")
+    @Operation(summary = "[선생님] 과외 정보 수정")
     @PutMapping("/{studyRoomId}")
     public ResponseEntity<Void> updateStudyRoom(@PathVariable Long studyRoomId, @RequestBody StudyRoomUpdateReqDto studyRoomUpdateReqDto){
         studyRoomService.updateStudyRoom(studyRoomId, studyRoomUpdateReqDto);
         return ResponseEntity.ok().build();
     }
 
-    @Operation(summary = "과외 정보 삭제")
+    @Operation(summary = "[선생님] 과외 정보 삭제")
     @DeleteMapping("/{studyRoomId}")
     public ResponseEntity<Void> deleteStudyRoom(@PathVariable Long studyRoomId){
         studyRoomService.deleteStudyRoom(studyRoomId);
@@ -57,11 +61,11 @@ public class StudyRoomController {
         return ResponseEntity.ok(subjectAndTeacherResDto);
     }
 
-    // 학생 ID 필요
     @Operation(summary = "[학생] 선생님-학생 연결")
     @PatchMapping("/connect")
-    public ResponseEntity<Void> connectTeacherStudent(@RequestParam(required = true) Integer code){
-        studyRoomService.connectTeacherStudent(4L, code);
+    public ResponseEntity<Void> connectTeacherStudent(@AuthenticationPrincipal CustomUserDetails user, @RequestParam(required = true) Integer code){
+        Long studentId = user.getMemberId();
+        studyRoomService.connectTeacherStudent(studentId, code);
         return ResponseEntity.ok().build();
     }
 
@@ -72,19 +76,20 @@ public class StudyRoomController {
         return ResponseEntity.ok().build();
     }
 
-    // 학생 or 선생님 ID 필요 (+ role)
     @Operation(summary = "진행중인 수업 조회 (+연결 여부)")
     @GetMapping
-    public ResponseEntity<List<StudyRoomResDto>> getStudyRooms(){
-        List<StudyRoomResDto> studyRoomResDtoList = studyRoomService.getStudyRooms(1L);
+    public ResponseEntity<List<StudyRoomResDto>> getStudyRooms(@AuthenticationPrincipal CustomUserDetails user){
+        Role role = user.getRole();
+        Long memberId = user.getMemberId();
+        List<StudyRoomResDto> studyRoomResDtoList = studyRoomService.getStudyRooms(role, memberId);
         return ResponseEntity.ok(studyRoomResDtoList);
     }
 
-    // 학생 or 선생님 ID 필요 (+ role)
     @Operation(summary = "진행중인 수업 상세 조회")
     @GetMapping("/{studyRoomId}")
-    public ResponseEntity<DetailedStudyRoomResDto> getDetailedStudyRooms(@PathVariable Long studyRoomId){
-        DetailedStudyRoomResDto detailedStudyRoomResDto = studyRoomService.getDetailedStudyRooms(studyRoomId);
+    public ResponseEntity<DetailedStudyRoomResDto> getDetailedStudyRooms(@AuthenticationPrincipal CustomUserDetails user, @PathVariable Long studyRoomId){
+        Role role = user.getRole();
+        DetailedStudyRoomResDto detailedStudyRoomResDto = studyRoomService.getDetailedStudyRooms(studyRoomId, role);
         return ResponseEntity.ok(detailedStudyRoomResDto);
     }
 }

--- a/src/main/java/turing/turing/domain/studyRoom/StudyRoomController.java
+++ b/src/main/java/turing/turing/domain/studyRoom/StudyRoomController.java
@@ -5,10 +5,11 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import turing.turing.domain.studyRoom.dto.DetailedStudyRoomResDto;
-import turing.turing.domain.studyRoom.dto.StudyRoomCreateReqDto;
-import turing.turing.domain.studyRoom.dto.StudyRoomResDto;
-import turing.turing.domain.studyRoom.dto.StudyRoomUpdateReqDto;
+import turing.turing.domain.studyRoom.dto.response.DetailedStudyRoomResDto;
+import turing.turing.domain.studyRoom.dto.request.StudyRoomCreateReqDto;
+import turing.turing.domain.studyRoom.dto.response.StudyRoomResDto;
+import turing.turing.domain.studyRoom.dto.request.StudyRoomUpdateReqDto;
+import turing.turing.domain.studyRoom.dto.response.SubjectAndTeacherResDto;
 
 import java.util.List;
 
@@ -42,15 +43,22 @@ public class StudyRoomController {
         return ResponseEntity.ok().build();
     }
 
-    @Operation(summary = "학생 연결 코드 조회 (코드 생성)")
+    @Operation(summary = "[선생님] 학생 연결 코드 조회 (코드 생성)")
     @GetMapping("/{studyRoomId}/codes")
     public ResponseEntity<Integer> getConnectionCode(@PathVariable Long studyRoomId){
         Integer code = studyRoomService.getConnectionCode(studyRoomId);
         return ResponseEntity.ok(code);
     }
 
+    @Operation(summary = "[학생] 연결 코드를 통한 선생님 조회 (연결할 선생님 조회)")
+    @GetMapping("/before-connect")
+    public ResponseEntity<SubjectAndTeacherResDto> getTeacherByCode(@RequestParam(required = true) Integer code){
+        SubjectAndTeacherResDto subjectAndTeacherResDto = studyRoomService.getTeacherByCode(code);
+        return ResponseEntity.ok(subjectAndTeacherResDto);
+    }
+
     // 학생 ID 필요
-    @Operation(summary = "선생님-학생 연결")
+    @Operation(summary = "[학생] 선생님-학생 연결")
     @PatchMapping("/connect")
     public ResponseEntity<Void> connectTeacherStudent(@RequestParam(required = true) Integer code){
         studyRoomService.connectTeacherStudent(4L, code);

--- a/src/main/java/turing/turing/domain/studyRoom/StudyRoomRepository.java
+++ b/src/main/java/turing/turing/domain/studyRoom/StudyRoomRepository.java
@@ -3,6 +3,7 @@ package turing.turing.domain.studyRoom;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import turing.turing.domain.student.Student;
 import turing.turing.domain.teacher.Teacher;
 
 import java.util.List;
@@ -16,6 +17,11 @@ public interface StudyRoomRepository extends JpaRepository<StudyRoom, Long> {
     List<StudyRoom> findAllWithStudentByTeacher(@Param(value = "teacher") Teacher teacher);
 
     @Query("select sr from StudyRoom sr " +
+            "join fetch sr.teacher t " +
+            "where sr.student = :student")
+    List<StudyRoom> findAllWithTeacherByStudent(@Param(value = "student") Student student);
+
+    @Query("select sr from StudyRoom sr " +
             "join fetch sr.student s " +
             "where sr.id = :studyRoomId")
     Optional<StudyRoom> findWithStudentById(@Param(value = "studyRoomId") Long studyRoomId);
@@ -25,6 +31,12 @@ public interface StudyRoomRepository extends JpaRepository<StudyRoom, Long> {
             "join fetch sr.student s " +
             "where sr.id = :studyRoomId")
     Optional<StudyRoom> findWithAllStudyTimeAndStudentById(@Param(value = "studyRoomId") Long studyRoomId);
+
+    @Query("select distinct sr from StudyRoom sr " +
+            "join fetch sr.studyTimes st " +
+            "join fetch sr.teacher t " +
+            "where sr.id = :studyRoomId")
+    Optional<StudyRoom> findWithAllStudyTimeAndTeacherById(@Param(value = "studyRoomId") Long studyRoomId);
 
     boolean existsByTeacherId(Long teacherId);
 

--- a/src/main/java/turing/turing/domain/studyRoom/StudyRoomService.java
+++ b/src/main/java/turing/turing/domain/studyRoom/StudyRoomService.java
@@ -9,10 +9,11 @@ import turing.turing.domain.schedule.Schedule;
 import turing.turing.domain.schedule.ScheduleRepository;
 import turing.turing.domain.student.Student;
 import turing.turing.domain.student.StudentRepository;
-import turing.turing.domain.studyRoom.dto.DetailedStudyRoomResDto;
-import turing.turing.domain.studyRoom.dto.StudyRoomCreateReqDto;
-import turing.turing.domain.studyRoom.dto.StudyRoomResDto;
-import turing.turing.domain.studyRoom.dto.StudyRoomUpdateReqDto;
+import turing.turing.domain.studyRoom.dto.response.DetailedStudyRoomResDto;
+import turing.turing.domain.studyRoom.dto.request.StudyRoomCreateReqDto;
+import turing.turing.domain.studyRoom.dto.response.StudyRoomResDto;
+import turing.turing.domain.studyRoom.dto.request.StudyRoomUpdateReqDto;
+import turing.turing.domain.studyRoom.dto.response.SubjectAndTeacherResDto;
 import turing.turing.domain.studyTime.StudyTime;
 import turing.turing.domain.studyTime.StudyTimeRepository;
 import turing.turing.domain.teacher.Teacher;
@@ -98,6 +99,18 @@ public class StudyRoomService {
                     connectionCodeRepository.save(connectionCode);
                     return connectionCode.getCode();
                 });
+    }
+
+    public SubjectAndTeacherResDto getTeacherByCode(Integer code){
+
+        ConnectionCode connectionCode = connectionCodeRepository.findWithStudyRoomAndTeacherByCode(code)
+                .orElseThrow(() -> new RestApiException(CommonErrorCode.NOT_FOUND));
+
+        String subject = connectionCode.getStudyRoom().getSubject();
+        String firstName = connectionCode.getStudyRoom().getTeacher().getFirstName();
+        String lastName = connectionCode.getStudyRoom().getTeacher().getLastName();
+
+        return new SubjectAndTeacherResDto(subject, firstName, lastName);
     }
 
     @Transactional

--- a/src/main/java/turing/turing/domain/studyRoom/StudyRoomService.java
+++ b/src/main/java/turing/turing/domain/studyRoom/StudyRoomService.java
@@ -64,7 +64,7 @@ public class StudyRoomService {
         StudyRoom studyRoom = studyRoomRepository.findById(studyRoomId)
                 .orElseThrow(() -> new RestApiException(CommonErrorCode.NOT_FOUND));
 
-        studyRoom.updateStudyRoom(studyRoomUpdateReqDto.subject(), studyRoomUpdateReqDto.baseSession());
+        studyRoom.updateStudyRoom(studyRoomUpdateReqDto.subject(), studyRoomUpdateReqDto.baseSession(), studyRoomUpdateReqDto.wage());
 
         // StudyTime의 경우, 요일이 추가/삭제될 수도 있기 때문에 변경 감지가 아닌 기존 StudyTime 삭제 후 다시 생성하도록 함
         studyTimeRepository.deleteByStudyRoomId(studyRoomId);  // 벌크 연산을 통해 삭제

--- a/src/main/java/turing/turing/domain/studyRoom/StudyRoomService.java
+++ b/src/main/java/turing/turing/domain/studyRoom/StudyRoomService.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import turing.turing.domain.code.ConnectionCode;
 import turing.turing.domain.code.ConnectionCodeRepository;
+import turing.turing.domain.member.Role;
 import turing.turing.domain.schedule.Schedule;
 import turing.turing.domain.schedule.ScheduleRepository;
 import turing.turing.domain.student.Student;
@@ -154,28 +155,41 @@ public class StudyRoomService {
         studyRoom.disconnectStudent(nonSignUpStudent);
     }
 
-    public List<StudyRoomResDto> getStudyRooms(Long memberId){
+    public List<StudyRoomResDto> getStudyRooms(Role role, Long memberId){
 
-        // role == teacher
-        Teacher teacher = teacherRepository.findById(memberId)
-                .orElseThrow(() -> new RestApiException(CommonErrorCode.NOT_FOUND));
+        List<StudyRoom> studyRoomList;
+        if(role == Role.TEACHER){
+            Teacher teacher = teacherRepository.findById(memberId)
+                    .orElseThrow(() -> new RestApiException(CommonErrorCode.NOT_FOUND));
 
-        List<StudyRoom> studyRoomList = studyRoomRepository.findAllWithStudentByTeacher(teacher);
+            studyRoomList = studyRoomRepository.findAllWithStudentByTeacher(teacher);
 
-        List<StudyRoomResDto> studyRoomResDtoList = studyRoomList.stream().map(StudyRoomResDto::of).toList();
+        } else {
+            Student student = studentRepository.findById(memberId)
+                    .orElseThrow(() -> new RestApiException(CommonErrorCode.NOT_FOUND));
+
+            studyRoomList = studyRoomRepository.findAllWithTeacherByStudent(student);
+        }
+
+        List<StudyRoomResDto> studyRoomResDtoList = studyRoomList.stream().map(studyRoom -> StudyRoomResDto.of(studyRoom, role)).toList();
         return studyRoomResDtoList;
     }
 
-    public DetailedStudyRoomResDto getDetailedStudyRooms(Long studyRoomId){
+    public DetailedStudyRoomResDto getDetailedStudyRooms(Long studyRoomId, Role role){
 
-        // role == teacher
-        StudyRoom studyRoom = studyRoomRepository.findWithAllStudyTimeAndStudentById(studyRoomId)
-                .orElseThrow(() -> new RestApiException(CommonErrorCode.NOT_FOUND));
+        StudyRoom studyRoom;
+        List<Schedule> scheduleList;
 
-        List<Schedule> scheduleList = scheduleRepository.findAllByStudyRoomOrderByDate(studyRoom);
+        if(role == Role.TEACHER) {
+            studyRoom = studyRoomRepository.findWithAllStudyTimeAndStudentById(studyRoomId)
+                    .orElseThrow(() -> new RestApiException(CommonErrorCode.NOT_FOUND));
+        } else {
+            studyRoom = studyRoomRepository.findWithAllStudyTimeAndTeacherById(studyRoomId)
+                    .orElseThrow(() -> new RestApiException(CommonErrorCode.NOT_FOUND));
+        }
 
-        DetailedStudyRoomResDto detailedStudyRoomResDto = DetailedStudyRoomResDto.of(studyRoom, scheduleList);
-        return detailedStudyRoomResDto;
+        scheduleList = scheduleRepository.findAllByStudyRoomOrderByDate(studyRoom);
+        return DetailedStudyRoomResDto.of(studyRoom, scheduleList, role);
     }
 
     // 중복되지 않는 6자리 연결 코드를 생성함

--- a/src/main/java/turing/turing/domain/studyRoom/dto/request/StudyRoomCreateReqDto.java
+++ b/src/main/java/turing/turing/domain/studyRoom/dto/request/StudyRoomCreateReqDto.java
@@ -1,4 +1,4 @@
-package turing.turing.domain.studyRoom.dto;
+package turing.turing.domain.studyRoom.dto.request;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import turing.turing.domain.student.Student;

--- a/src/main/java/turing/turing/domain/studyRoom/dto/request/StudyRoomUpdateReqDto.java
+++ b/src/main/java/turing/turing/domain/studyRoom/dto/request/StudyRoomUpdateReqDto.java
@@ -11,6 +11,6 @@ public record StudyRoomUpdateReqDto(
         List<StudyTimeReqDto> studyTimes,
         Integer baseSession,
         @JsonFormat(pattern = "yyyy-MM-dd")
-        LocalDate startDate
+        Integer wage
 ) {
 }

--- a/src/main/java/turing/turing/domain/studyRoom/dto/request/StudyRoomUpdateReqDto.java
+++ b/src/main/java/turing/turing/domain/studyRoom/dto/request/StudyRoomUpdateReqDto.java
@@ -1,4 +1,4 @@
-package turing.turing.domain.studyRoom.dto;
+package turing.turing.domain.studyRoom.dto.request;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import turing.turing.domain.studyTime.dto.StudyTimeReqDto;

--- a/src/main/java/turing/turing/domain/studyRoom/dto/response/DetailedStudyRoomResDto.java
+++ b/src/main/java/turing/turing/domain/studyRoom/dto/response/DetailedStudyRoomResDto.java
@@ -1,4 +1,4 @@
-package turing.turing.domain.studyRoom.dto;
+package turing.turing.domain.studyRoom.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import turing.turing.domain.schedule.Schedule;

--- a/src/main/java/turing/turing/domain/studyRoom/dto/response/DetailedStudyRoomResDto.java
+++ b/src/main/java/turing/turing/domain/studyRoom/dto/response/DetailedStudyRoomResDto.java
@@ -1,6 +1,7 @@
 package turing.turing.domain.studyRoom.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import turing.turing.domain.member.Role;
 import turing.turing.domain.schedule.Schedule;
 import turing.turing.domain.studyRoom.StudyRoom;
 import turing.turing.domain.studyTime.dto.StudyTimeResDto;
@@ -10,8 +11,8 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 public record DetailedStudyRoomResDto(
-        String studentFirstName,
-        String studentLastName,
+        String oppositeFirstName,
+        String oppositeLastName,
         String subject,
         String studentSchool,
         String studentYear,
@@ -25,7 +26,7 @@ public record DetailedStudyRoomResDto(
         Integer totalSession,
         Integer totalBaseSession
 ) {
-    public static DetailedStudyRoomResDto of(StudyRoom studyRoom, List<Schedule> schedules) {
+    public static DetailedStudyRoomResDto of(StudyRoom studyRoom, List<Schedule> schedules, Role role) {
 
         // 수업 시작일
         LocalDate firstSchedule = schedules.isEmpty() ? null : schedules.get(0).getDate();
@@ -46,11 +47,11 @@ public record DetailedStudyRoomResDto(
         Integer totalBaseSession = (schedule == null ? 0: schedules.size());
 
         return new DetailedStudyRoomResDto(
-                studyRoom.getStudent().getFirstName(),
-                studyRoom.getStudent().getLastName(),
+                role == Role.TEACHER ? studyRoom.getStudent().getFirstName() : studyRoom.getTeacher().getFirstName(),
+                role == Role.TEACHER ? studyRoom.getStudent().getLastName() : studyRoom.getTeacher().getLastName(),
                 studyRoom.getSubject(),
-                studyRoom.getStudent().getSchool(),
-                studyRoom.getStudent().getYear(),
+                role == Role.TEACHER ? studyRoom.getStudent().getSchool() : null,
+                role == Role.TEACHER ? studyRoom.getStudent().getYear() : null,
                 studyRoom.getStudyTimes().stream().map(StudyTimeResDto::of).toList(),
                 studyRoom.getBaseSession(),
                 firstSchedule,

--- a/src/main/java/turing/turing/domain/studyRoom/dto/response/StudyRoomResDto.java
+++ b/src/main/java/turing/turing/domain/studyRoom/dto/response/StudyRoomResDto.java
@@ -1,4 +1,4 @@
-package turing.turing.domain.studyRoom.dto;
+package turing.turing.domain.studyRoom.dto.response;
 
 import turing.turing.domain.studyRoom.StudyRoom;
 

--- a/src/main/java/turing/turing/domain/studyRoom/dto/response/StudyRoomResDto.java
+++ b/src/main/java/turing/turing/domain/studyRoom/dto/response/StudyRoomResDto.java
@@ -1,19 +1,20 @@
 package turing.turing.domain.studyRoom.dto.response;
 
+import turing.turing.domain.member.Role;
 import turing.turing.domain.studyRoom.StudyRoom;
 
 public record StudyRoomResDto(
         Long id,
-        String studentFirstName,
-        String studentLastName,
+        String opponentFirstName,
+        String opponentLastName,
         String subject,
         Boolean linkStatus
 ) {
-    public static StudyRoomResDto of(StudyRoom studyRoom) {
+    public static StudyRoomResDto of(StudyRoom studyRoom, Role role) {
         return new StudyRoomResDto(
                 studyRoom.getId(),
-                studyRoom.getStudent().getFirstName(),
-                studyRoom.getStudent().getLastName(),
+                role == Role.TEACHER ? studyRoom.getStudent().getFirstName() : studyRoom.getTeacher().getFirstName(),
+                role == Role.TEACHER ? studyRoom.getStudent().getLastName() : studyRoom.getTeacher().getLastName(),
                 studyRoom.getSubject(),
                 studyRoom.getLinkStatus()
         );

--- a/src/main/java/turing/turing/domain/studyRoom/dto/response/SubjectAndTeacherResDto.java
+++ b/src/main/java/turing/turing/domain/studyRoom/dto/response/SubjectAndTeacherResDto.java
@@ -1,0 +1,8 @@
+package turing.turing.domain.studyRoom.dto.response;
+
+public record SubjectAndTeacherResDto(
+        String subject,
+        String teacherFirstName,
+        String teacherLastName
+) {
+}


### PR DESCRIPTION
## 📄 Description

- close : #51 

> 과외 공간 도메인의 추가된 사항(학생 화면) 및 수정된 사항을 반영하고, 스프링 시큐리티 적용에 따라 사용자 정보를 가져와 전달하도록 수정하였습니다.

## 📌 구현 내용

- [x] Figma 화면 수정됨에 따라 과외 정보 수정 startDate -> wage 수정
- [x] "진행중인 수업 조회", "수업 상세 조회" API 선생님/학생 통합
- [x] @AuthenticationPrincipal 적용
- [x] 연결코드를 통한 선생님 조회 API 구현