### PR TITLE
[Fix] 응답 데이터에 알림을 위한 정보 추가

### DIFF
--- a/src/main/java/turing/turing/domain/alternativeSchedule/AlternativeController.java
+++ b/src/main/java/turing/turing/domain/alternativeSchedule/AlternativeController.java
@@ -4,6 +4,7 @@ import java.net.URI;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -13,6 +14,9 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 import turing.turing.domain.alternativeSchedule.dto.AllAlterSchedules;
 import turing.turing.domain.alternativeSchedule.dto.CreateAlterScheduleRequest;
+import turing.turing.domain.alternativeSchedule.dto.CreateAlterScheduleResponse;
+import turing.turing.domain.auth.CustomUserDetails;
+import turing.turing.domain.member.Role;
 
 @RestController
 @RequiredArgsConstructor
@@ -28,14 +32,15 @@ public class AlternativeController {
     }
 
     @PostMapping("/")
-    public ResponseEntity<CreateAlterScheduleRequest> createAlterSchedule(@RequestBody CreateAlterScheduleRequest request) {
-        Long firstSavedId = alternativeService.createAlterSchedule(request);
+    public ResponseEntity<CreateAlterScheduleResponse> createAlterSchedule(@AuthenticationPrincipal CustomUserDetails customUserDetails, @RequestBody CreateAlterScheduleRequest request) {
+        CreateAlterScheduleResponse response = alternativeService.createAlterSchedules(request);
+        response.setSender(customUserDetails.getMemberId(), Role.STUDENT);
 
         URI location = ServletUriComponentsBuilder.fromCurrentRequest()
                 .path("/{alterScheduleId}")
-                .buildAndExpand(firstSavedId)
+                .buildAndExpand(response.getFirstAlterScheduleId())
                 .toUri();
 
-        return ResponseEntity.created(location).build();
+        return ResponseEntity.created(location).body(response);
     }
 }

--- a/src/main/java/turing/turing/domain/alternativeSchedule/AlternativeService.java
+++ b/src/main/java/turing/turing/domain/alternativeSchedule/AlternativeService.java
@@ -12,7 +12,9 @@ import turing.turing.domain.alternativeSchedule.converter.AlterScheduleConverter
 import turing.turing.domain.alternativeSchedule.dto.AlterScheduleDto;
 import turing.turing.domain.alternativeSchedule.dto.CreateAlterScheduleRequest;
 import turing.turing.domain.alternativeSchedule.dto.AllAlterSchedules;
+import turing.turing.domain.alternativeSchedule.dto.CreateAlterScheduleResponse;
 import turing.turing.domain.alternativeSchedule.dto.TimePairDto;
+import turing.turing.domain.member.Role;
 import turing.turing.domain.schedule.Schedule;
 import turing.turing.domain.schedule.ScheduleRepository;
 import turing.turing.domain.alternativeSchedule.dto.ToAlterScheduleDto;
@@ -75,9 +77,12 @@ public class AlternativeService {
 
     //TODO saveAll -> bulkInsert 개선 필요
     @Transactional
-    public Long createAlterSchedule(CreateAlterScheduleRequest request) {
+    public CreateAlterScheduleResponse createAlterSchedules(CreateAlterScheduleRequest request) {
         Schedule schedule = scheduleRepository.findById(request.getTargetScheduleId())
                 .orElseThrow(() -> new RestApiException(CommonErrorCode.NOT_FOUND));
+        Long teacherId = schedule.getStudyRoom()
+                .getTeacher()
+                .getId();
 
         Map<LocalDate, List<TimePairDto>> alterScheduleList = request.getAlterScheduleList();
         Set<LocalDate> ketSet = alterScheduleList.keySet();
@@ -98,6 +103,13 @@ public class AlternativeService {
                 );
             }
         }
-        return alternativeScheduleRepository.saveAll(result).get(0).getId();
+        Long firstSavedId = alternativeScheduleRepository.saveAll(result).get(0).getId();
+
+        return CreateAlterScheduleResponse.builder()
+                .firstAlterScheduleId(firstSavedId)
+                .scheduleDate(schedule.getDate())
+                .receiverId(teacherId)
+                .receiverRole(Role.TEACHER)
+                .build();
     }
 }

--- a/src/main/java/turing/turing/domain/alternativeSchedule/dto/CreateAlterScheduleResponse.java
+++ b/src/main/java/turing/turing/domain/alternativeSchedule/dto/CreateAlterScheduleResponse.java
@@ -1,16 +1,14 @@
 package turing.turing.domain.alternativeSchedule.dto;
 
-import lombok.Builder;
+import java.time.LocalDate;
 import lombok.Getter;
-import turing.turing.domain.member.Role;
+import lombok.experimental.SuperBuilder;
+import turing.turing.domain.notice.dto.BaseNoticeInfo;
 
 @Getter
-@Builder
-public class CreateAlterScheduleResponse {
+@SuperBuilder
+public class CreateAlterScheduleResponse extends BaseNoticeInfo {
 
     private Long firstAlterScheduleId;
-    public Long senderId;
-    public Role senderRole;
-    public Long receiverId;
-    public Role receiverRole;
+    private LocalDate scheduleDate;
 }

--- a/src/main/java/turing/turing/domain/exam/ExamController.java
+++ b/src/main/java/turing/turing/domain/exam/ExamController.java
@@ -4,7 +4,6 @@ import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -14,7 +13,9 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+import turing.turing.domain.auth.CustomUserDetails;
 import turing.turing.domain.exam.dto.CreateExamRequest;
+import turing.turing.domain.exam.dto.CreateExamResponse;
 import turing.turing.domain.exam.dto.ExamDto;
 
 @RestController
@@ -32,16 +33,16 @@ public class ExamController {
     }
 
     @PostMapping("/")
-    public ResponseEntity<Long> createExamSchedule(@AuthenticationPrincipal UserDetails userDetails, @RequestBody CreateExamRequest request) {
-        Long savedId = examService.createExamSchedule(request);
-
+    public ResponseEntity<CreateExamResponse> createExamSchedule(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails, @RequestBody CreateExamRequest request) {
+        CreateExamResponse response = examService.createExamSchedules(customUserDetails, request);
 
         URI location = ServletUriComponentsBuilder.fromCurrentRequest()
                 .path("/{examId}")
-                .buildAndExpand(savedId)
+                .buildAndExpand(response.getExamId())
                 .toUri();
 
-        return ResponseEntity.created(location).build();
+        return ResponseEntity.created(location).body(response);
     }
 
     @PatchMapping("/")

--- a/src/main/java/turing/turing/domain/exam/ExamService.java
+++ b/src/main/java/turing/turing/domain/exam/ExamService.java
@@ -3,9 +3,12 @@ package turing.turing.domain.exam;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import turing.turing.domain.auth.CustomUserDetails;
 import turing.turing.domain.exam.converter.ExamConverter;
 import turing.turing.domain.exam.dto.CreateExamRequest;
+import turing.turing.domain.exam.dto.CreateExamResponse;
 import turing.turing.domain.exam.dto.ExamDto;
+import turing.turing.domain.member.Role;
 import turing.turing.domain.studyRoom.StudyRoom;
 import turing.turing.domain.studyRoom.StudyRoomRepository;
 import turing.turing.global.exception.RestApiException;
@@ -13,13 +16,12 @@ import turing.turing.global.exception.errorCode.CommonErrorCode;
 
 @Service
 @RequiredArgsConstructor
-@Transactional
+@Transactional(readOnly = true)
 public class ExamService {
 
     private final ExamRepository examRepository;
     private final StudyRoomRepository studyRoomRepository;
 
-    @Transactional(readOnly = true)
     public ExamDto getExamSchedule(Long examId) {
         Exam exam = examRepository.findById(examId)
                 .orElseThrow(() -> new RestApiException(CommonErrorCode.NOT_FOUND));
@@ -27,15 +29,21 @@ public class ExamService {
         return ExamConverter.toDto(exam);
     }
 
-    public Long createExamSchedule(CreateExamRequest request) {
+    @Transactional
+    public CreateExamResponse createExamSchedules(CustomUserDetails customUserDetails, CreateExamRequest request) {
         StudyRoom studyRoom = studyRoomRepository.findById(request.getStudyRoomId())
                 .orElseThrow(() -> new RestApiException(CommonErrorCode.NOT_FOUND));
 
         Exam exam = ExamConverter.toEntity(request, studyRoom);
+        Long examId = examRepository.save(exam).getId();
 
-        return examRepository.save(exam).getId();
+        CreateExamResponse response = setBaseField(customUserDetails, studyRoom);
+        response.setExamId(examId);
+
+        return response;
     }
 
+    @Transactional
     public Long modifyExamSchedule(ExamDto request) {
         Exam exam = examRepository.findById(request.getExamId())
                 .orElseThrow(() -> new RestApiException(CommonErrorCode.NOT_FOUND));
@@ -46,6 +54,7 @@ public class ExamService {
         return exam.update(request, studyRoom);
     }
 
+    @Transactional
     public void deleteExamSchedule(Long examId) {
         Exam exam = examRepository.findById(examId)
                 .orElseThrow(() -> new RestApiException(CommonErrorCode.NOT_FOUND));
@@ -53,4 +62,24 @@ public class ExamService {
         examRepository.delete(exam);
     }
 
+    private CreateExamResponse setBaseField(CustomUserDetails customUserDetails, StudyRoom studyRoom) {
+        Long receiverId;
+        Role receiverRole;
+        Role senderRole = customUserDetails.getRole();
+
+        if (senderRole.equals(Role.STUDENT)) {
+            receiverId = studyRoom.getTeacher().getId();
+            receiverRole = Role.TEACHER;
+        } else {
+            receiverId = studyRoom.getStudent().getId();
+            receiverRole = Role.STUDENT;
+        }
+
+        return CreateExamResponse.builder()
+                .receiverId(receiverId)
+                .receiverRole(receiverRole)
+                .senderId(customUserDetails.getMemberId())
+                .senderRole(senderRole)
+                .build();
+    }
 }

--- a/src/main/java/turing/turing/domain/exam/dto/CreateExamResponse.java
+++ b/src/main/java/turing/turing/domain/exam/dto/CreateExamResponse.java
@@ -1,16 +1,15 @@
 package turing.turing.domain.exam.dto;
 
-import lombok.Builder;
 import lombok.Getter;
-import turing.turing.domain.member.Role;
+import lombok.experimental.SuperBuilder;
+import turing.turing.domain.notice.dto.BaseNoticeInfo;
 
 @Getter
-@Builder
-public class CreateExamResponse {
-
+@SuperBuilder
+public class CreateExamResponse extends BaseNoticeInfo {
     private Long examId;
-    public Long senderId;
-    public Role senderRole;
-    public Long receiverId;
-    public Role receiverRole;
+
+    public void setExamId(Long examId) {
+        this.examId = examId;
+    }
 }

--- a/src/main/java/turing/turing/domain/notebook/NotebookController.java
+++ b/src/main/java/turing/turing/domain/notebook/NotebookController.java
@@ -19,7 +19,9 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 import turing.turing.domain.auth.CustomUserDetails;
-import turing.turing.domain.notebook.dto.CreateNotebookDto;
+import turing.turing.domain.member.Role;
+import turing.turing.domain.notebook.dto.CreateNotebookRequest;
+import turing.turing.domain.notebook.dto.CreateNotebookResponse;
 import turing.turing.domain.notebook.dto.HomeworkPercentAllDto;
 import turing.turing.domain.notebook.dto.ModifyDeadlineDto;
 import turing.turing.domain.notebook.dto.NotebookInfo;
@@ -56,15 +58,17 @@ public class NotebookController {
 
     @Operation(summary = "알림장 생성")
     @PostMapping("")
-    public ResponseEntity<Long> createNotebook(@RequestBody CreateNotebookDto request) {
-        Long savedId = notebookService.createNotebook(request);
+    public ResponseEntity<CreateNotebookResponse> createNotebook(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails, @RequestBody CreateNotebookRequest request) {
+        CreateNotebookResponse response = notebookService.createNotebook(request);
+        response.setSender(customUserDetails.getMemberId(), Role.TEACHER);
 
         URI location = ServletUriComponentsBuilder.fromCurrentRequest()
                 .path("/{notebookId}")
-                .buildAndExpand(savedId)
+                .buildAndExpand(response.getNotebookId())
                 .toUri();
 
-        return ResponseEntity.created(location).build();
+        return ResponseEntity.created(location).body(response);
 
     }
 

--- a/src/main/java/turing/turing/domain/notebook/NotebookService.java
+++ b/src/main/java/turing/turing/domain/notebook/NotebookService.java
@@ -18,12 +18,14 @@ import turing.turing.domain.homework.Homework;
 import turing.turing.domain.homework.HomeworkRepository;
 import turing.turing.domain.homework.converter.HomeworkConverter;
 import turing.turing.domain.homework.dto.HomeworkDto;
-import turing.turing.domain.notebook.dto.CreateNotebookDto;
+import turing.turing.domain.notebook.dto.CreateNotebookRequest;
+import turing.turing.domain.notebook.dto.CreateNotebookResponse;
 import turing.turing.domain.notebook.dto.HomeworkPercentAllDto;
 import turing.turing.domain.notebook.dto.ModifyDeadlineDto;
 import turing.turing.domain.notebook.dto.NotebookInfo;
 import turing.turing.domain.schedule.Schedule;
 import turing.turing.domain.schedule.ScheduleRepository;
+import turing.turing.domain.student.StudentRepository;
 import turing.turing.global.exception.RestApiException;
 import turing.turing.global.exception.errorCode.CommonErrorCode;
 
@@ -34,6 +36,7 @@ public class NotebookService {
     private final HomeworkRepository homeworkRepository;
     private final NotebookRepository notebookRepository;
     private final ScheduleRepository scheduleRepository;
+    private final StudentRepository studentRepository;
 
     @Transactional(readOnly = true)
     public NotebookInfo getNotebook(Long notebookId, Boolean b) {
@@ -91,7 +94,7 @@ public class NotebookService {
     }
 
     @Transactional
-    public Long createNotebook(CreateNotebookDto request) {
+    public CreateNotebookResponse createNotebook(CreateNotebookRequest request) {
         Schedule schedule = scheduleRepository.findById(request.getScheduleId())
                 .orElseThrow(() -> new RestApiException(CommonErrorCode.NOT_FOUND));
 
@@ -102,9 +105,14 @@ public class NotebookService {
         Timestamp timestamp = confirmDeadline(request.getDeadline(), deadlineTime);
 
         Notebook notebook = new Notebook(schedule, timestamp);
-        notebookRepository.save(notebook);
+        Long notebookId = notebookRepository.save(notebook).getId();
 
-        return notebook.getId();
+        Long studentId = studentRepository.findByScheduleId(schedule.getId());
+        return CreateNotebookResponse.builder()
+                .notebookId(notebookId)
+                .receiverId(studentId)
+                .receiverRole(Role.STUDENT)
+                .build();
     }
 
     @Transactional

--- a/src/main/java/turing/turing/domain/notebook/dto/CreateNotebookRequest.java
+++ b/src/main/java/turing/turing/domain/notebook/dto/CreateNotebookRequest.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-public class CreateNotebookDto {
+public class CreateNotebookRequest {
 
     private Long scheduleId;
 

--- a/src/main/java/turing/turing/domain/notebook/dto/CreateNotebookResponse.java
+++ b/src/main/java/turing/turing/domain/notebook/dto/CreateNotebookResponse.java
@@ -1,0 +1,12 @@
+package turing.turing.domain.notebook.dto;
+
+import lombok.Getter;
+import lombok.experimental.SuperBuilder;
+import turing.turing.domain.notice.dto.BaseNoticeInfo;
+
+@Getter
+@SuperBuilder
+public class CreateNotebookResponse extends BaseNoticeInfo {
+
+    private Long notebookId;
+}

--- a/src/main/java/turing/turing/domain/notice/dto/BaseNoticeInfo.java
+++ b/src/main/java/turing/turing/domain/notice/dto/BaseNoticeInfo.java
@@ -1,15 +1,20 @@
 package turing.turing.domain.notice.dto;
 
-import lombok.Builder;
 import lombok.Getter;
+import lombok.experimental.SuperBuilder;
 import turing.turing.domain.member.Role;
 
 @Getter
-@Builder
+@SuperBuilder
 public class BaseNoticeInfo {
 
-    public Long senderId;
-    public Role senderRole;
-    public Long receiverId;
-    public Role receiverRole;
+    protected Long senderId;
+    protected Role senderRole;
+    protected Long receiverId;
+    protected Role receiverRole;
+
+    public void setSender(Long senderId, Role senderRole) {
+        this.senderId = senderId;
+        this.senderRole = senderRole;
+    }
 }

--- a/src/main/java/turing/turing/domain/schedule/Schedule.java
+++ b/src/main/java/turing/turing/domain/schedule/Schedule.java
@@ -74,20 +74,16 @@ public class Schedule extends BaseEntity {
         this.studyRoom = studyRoom;
     }
 
-    public Long update(ModifyScheduleRequest request) {
+    public void update(ModifyScheduleRequest request) {
         this.date = request.getDate();
         this.startTime = request.getStartTime();
         this.endTime = request.getEndTime();
-
-        return this.id;
     }
 
-    public Long updateWithSession(UpdateScheduleDto request) {
+    public void updateWithSession(UpdateScheduleDto request) {
         this.date = request.getDate();
         this.startTime = request.getStartTime();
         this.endTime = request.getEndTime();
         this.session = request.getSession();
-
-        return this.id;
     }
 }

--- a/src/main/java/turing/turing/domain/schedule/ScheduleController.java
+++ b/src/main/java/turing/turing/domain/schedule/ScheduleController.java
@@ -5,6 +5,7 @@ import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -14,8 +15,11 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+import turing.turing.domain.auth.CustomUserDetails;
+import turing.turing.domain.member.Role;
 import turing.turing.domain.schedule.dto.CreateScheduleRequest;
 import turing.turing.domain.schedule.dto.ModifyScheduleRequest;
+import turing.turing.domain.schedule.dto.ModifyScheduleResponse;
 import turing.turing.domain.schedule.dto.ScheduleDto;
 
 @RestController
@@ -51,9 +55,11 @@ public class ScheduleController {
     }
 
     @PatchMapping("/")
-    public ResponseEntity<Long> modifySchedule(@RequestBody ModifyScheduleRequest request) {
+    public ResponseEntity<ModifyScheduleResponse> modifySchedule(@AuthenticationPrincipal CustomUserDetails customUserDetails, @RequestBody ModifyScheduleRequest request) {
+        ModifyScheduleResponse response = scheduleService.modifySchedules(request);
+        response.setSender(customUserDetails.getMemberId(), Role.TEACHER);
 
-        return ResponseEntity.ok(scheduleService.modifySchedule(request));
+        return ResponseEntity.ok(response);
     }
 
 }

--- a/src/main/java/turing/turing/domain/schedule/ScheduleRepository.java
+++ b/src/main/java/turing/turing/domain/schedule/ScheduleRepository.java
@@ -52,6 +52,7 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
     @NonNull
     @Query("select s from Schedule s "
             + "join fetch StudyRoom sr "
+            + "join fetch Teacher t "
             + "where s.id = :scheduleId")
     Optional<Schedule> findById(@NonNull @Param("scheduleId") Long scheduleId);
 

--- a/src/main/java/turing/turing/domain/schedule/ScheduleRepository.java
+++ b/src/main/java/turing/turing/domain/schedule/ScheduleRepository.java
@@ -52,7 +52,6 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
     @NonNull
     @Query("select s from Schedule s "
             + "join fetch StudyRoom sr "
-            + "join fetch Teacher t "
             + "where s.id = :scheduleId")
     Optional<Schedule> findById(@NonNull @Param("scheduleId") Long scheduleId);
 

--- a/src/main/java/turing/turing/domain/schedule/ScheduleService.java
+++ b/src/main/java/turing/turing/domain/schedule/ScheduleService.java
@@ -6,10 +6,13 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import turing.turing.domain.member.Role;
 import turing.turing.domain.schedule.dto.CreateScheduleRequest;
 import turing.turing.domain.schedule.dto.ModifyScheduleRequest;
+import turing.turing.domain.schedule.dto.ModifyScheduleResponse;
 import turing.turing.domain.schedule.dto.ScheduleDto;
 import turing.turing.domain.schedule.dto.UpdateScheduleDto;
+import turing.turing.domain.student.StudentRepository;
 import turing.turing.domain.studyRoom.StudyRoom;
 import turing.turing.domain.studyRoom.StudyRoomRepository;
 import turing.turing.domain.studyTime.dto.StudyTimeReqDto;
@@ -23,6 +26,7 @@ public class ScheduleService {
 
     private final ScheduleRepository scheduleRepository;
     private final StudyRoomRepository studyRoomRepository;
+    private final StudentRepository studentRepository;
 
     public List<ScheduleDto> getMonthSchedules(LocalDate date, List<Long> studyRoomIds) {
         int month = date.getMonthValue();
@@ -95,7 +99,7 @@ public class ScheduleService {
     }
 
     @Transactional
-    public Long modifySchedule(ModifyScheduleRequest request) {
+    public ModifyScheduleResponse modifySchedules(ModifyScheduleRequest request) {
         Long scheduleId = request.getScheduleId();
         LocalDate modifiedDate = request.getDate();
         List<Schedule> scheduleList = scheduleRepository.findAllByIdAndDate(scheduleId, modifiedDate);
@@ -107,28 +111,50 @@ public class ScheduleService {
                 .map(Schedule::getId)
                 .toList();
 
+        LocalDate prevDate;
+        Schedule firstSchedule = scheduleList.get(0);
         //일정 변경이 다른 일정과 엇갈리지 않는 경우
         if (scheduleList.size() == 1) {
-            return scheduleList.get(0).update(request);
+            prevDate = firstSchedule.getDate();
+            firstSchedule.update(request);
         } //일정을 나중으로 미루는 경우
-        else if (scheduleList.get(0).getId().equals(request.getScheduleId())) {
+        else if (firstSchedule.getId().equals(request.getScheduleId())) {
+            prevDate = firstSchedule.getDate();
             scheduleRepository.moveUpSchedules(scheduleIds);
-            Schedule targetSchedule = scheduleList.get(0);
 
-            UpdateScheduleDto dto = UpdateScheduleDto.of(request.getDate(), request.getStartTime(), request.getEndTime(),
-                    scheduleList.get(scheduleList.size() - 1).getSession());
+            UpdateScheduleDto dto = UpdateScheduleDto.builder()
+                    .date(request.getDate())
+                    .startTime(request.getStartTime())
+                    .endTime(request.getEndTime())
+                    .session(scheduleList.get(scheduleList.size() - 1).getSession())
+                    .build();
 
-            return targetSchedule.updateWithSession(dto);
+            firstSchedule.updateWithSession(dto);
         } //일정을 앞으로 땡기는 경우
         else {
             scheduleRepository.postponeSchedules(scheduleIds);
             Schedule targetSchedule = scheduleList.get(scheduleList.size() - 1);
+            prevDate = targetSchedule.getDate();
 
-            UpdateScheduleDto dto = UpdateScheduleDto.of(request.getDate(), request.getStartTime(), request.getEndTime(),
-                    scheduleList.get(0).getSession());
+            UpdateScheduleDto dto = UpdateScheduleDto.builder()
+                    .date(request.getDate())
+                    .startTime(request.getStartTime())
+                    .endTime(request.getEndTime())
+                    .session(firstSchedule.getSession())
+                    .build();
 
-            return targetSchedule.updateWithSession(dto);
+            targetSchedule.updateWithSession(dto);
         }
+
+        Long studentId = studentRepository.findByScheduleId(scheduleId);
+
+        return ModifyScheduleResponse.builder()
+                .scheduleId(scheduleId)
+                .prevDate(prevDate)
+                .alterDate(modifiedDate)
+                .receiverId(studentId)
+                .receiverRole(Role.STUDENT)
+                .build();
     }
 
 }

--- a/src/main/java/turing/turing/domain/schedule/dto/ModifyScheduleResponse.java
+++ b/src/main/java/turing/turing/domain/schedule/dto/ModifyScheduleResponse.java
@@ -1,0 +1,15 @@
+package turing.turing.domain.schedule.dto;
+
+import java.time.LocalDate;
+import lombok.Getter;
+import lombok.experimental.SuperBuilder;
+import turing.turing.domain.notice.dto.BaseNoticeInfo;
+
+@Getter
+@SuperBuilder
+public class ModifyScheduleResponse extends BaseNoticeInfo {
+
+    private Long scheduleId;
+    private LocalDate prevDate;
+    private LocalDate alterDate;
+}

--- a/src/main/java/turing/turing/domain/schedule/dto/UpdateScheduleDto.java
+++ b/src/main/java/turing/turing/domain/schedule/dto/UpdateScheduleDto.java
@@ -17,14 +17,4 @@ public class UpdateScheduleDto {
 
     private Integer session;
 
-    public static UpdateScheduleDto of(LocalDate date, LocalTime startTime, LocalTime endTime,
-            Integer session) {
-
-        return UpdateScheduleDto.builder()
-                .date(date)
-                .startTime(startTime)
-                .endTime(endTime)
-                .session(session)
-                .build();
-    }
 }

--- a/src/main/java/turing/turing/domain/student/StudentRepository.java
+++ b/src/main/java/turing/turing/domain/student/StudentRepository.java
@@ -2,6 +2,8 @@ package turing.turing.domain.student;
 
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import turing.turing.domain.member.Provider;
 
 public interface StudentRepository extends JpaRepository<Student, Long> {
@@ -9,4 +11,10 @@ public interface StudentRepository extends JpaRepository<Student, Long> {
     Optional<Student> findByEmail(String email);
 
     Optional<Student> findByEmailAndProvider(String email, Provider provider);
+
+    @Query("select s.id from Student s "
+            + "join StudyRoom sr on s.id = sr.student.id "
+            + "join Schedule sd on sr.id = sd.studyRoom.id "
+            + "where sd.id = :scheduleId")
+    Long findByScheduleId(@Param("scheduleId") Long scheduleId);
 }


### PR DESCRIPTION
## 📄 Description

- close : #42 

## 📌 구현 내용
- 공통 정보 : 송/수신 사용자 Id, 역할
- 추가 정보
    - 시험 생성 응답 : 생성한 시험 Id
    - 알림장 생성 응답 : 생성한 알림장 Id
    - 수업 일정 변경 확정 응답 : 변경 대상 날짜, 변경된 날짜
    - 수업 일정 변경 요청 생성 응답 : 변경 대상 날짜

## ✅ PR 포인트
- BaseNoticeInfo 객체로 알림에 사용되는 공통 정보들을 관리하였습니다.
    - 응답 정보에 알림정보가 필요한 객체들은 BaseNoticeInfo 객체를 상속받도록 하였습니다.
    - 서브타입 객체에서 빌더패턴을 적용하기 위해 SuperBuilder 어노테이션을 사용하였습니다.