### PR TITLE
[Fix] 학생 연결 시 학교, 학년 정보를 동기화하도록 수정

### DIFF
--- a/src/main/java/turing/turing/domain/student/Student.java
+++ b/src/main/java/turing/turing/domain/student/Student.java
@@ -74,4 +74,10 @@ public class Student extends Member {
         this.phone = phone;
         this.parentPhone = parentPhone;
     }
+
+    // 학생 연결 시 기존 정보를 동기화하기 위해 사용
+    public void updateSchoolAndYear(String school, String year) {
+        this.school = school;
+        this.year = year;
+    }
 }

--- a/src/main/java/turing/turing/domain/studyRoom/StudyRoomService.java
+++ b/src/main/java/turing/turing/domain/studyRoom/StudyRoomService.java
@@ -25,7 +25,6 @@ import turing.turing.domain.studyTime.dto.StudyTimeResDto;
 import turing.turing.domain.teacher.Teacher;
 import turing.turing.domain.teacher.TeacherRepository;
 import turing.turing.global.exception.RestApiException;
-import turing.turing.global.exception.errorCode.CommonErrorCode;
 import turing.turing.global.exception.errorCode.StudyRoomErrorCode;
 import turing.turing.global.exception.errorCode.UserErrorCode;
 
@@ -61,7 +60,7 @@ public class StudyRoomService {
         studyTimeRepository.saveAll(studyTimes);
 
 
-        // 기준회차 생성g
+        // 기준회차 생성
         CreateScheduleRequest createScheduleRequest = new CreateScheduleRequest(
                 studyRoom.getId(),
                 studyRoomCreateReqDto.studentLastName() + studyRoomCreateReqDto.studentFirstName(),
@@ -142,7 +141,8 @@ public class StudyRoomService {
         // 기존 학생 가져오기
         Student nonSignUpStudent = connectionCode.getStudyRoom().getStudent();
 
-        // 실제로 가입한 학생과 연결 (참조를 변경)
+        // 학생 정보를 업데이트하고, 실제로 가입한 학생과 연결 (참조를 변경)
+        student.updateSchoolAndYear(nonSignUpStudent.getSchool(), nonSignUpStudent.getYear());
         connectionCode.getStudyRoom().connectStudent(student);
 
         // 기존 학생은 삭제


### PR DESCRIPTION
## 📄 Description

- close : #84 

> 학생 연결 시 기존 정보를 동기화하도록 수정하였습니다.

## 📌 구현 내용

- [x] connectTeacherStudent에서 기존(미연결) 학생의 정보를 실제 학생 엔티티에 반영함

## ✅ PR 포인트

이렇게 하면 선생님이 입력한 정보에 의존되게 되지만, 현재 따로 학생이 설정하는 부분이 없는 관계로 이렇게 진행하였습니다.