### PR TITLE
[Fix]: 자동로그인 시 필터를 거쳐서 토큰의 정보를 사용하도록 수정

### DIFF
--- a/src/main/java/turing/turing/domain/auth/AuthController.java
+++ b/src/main/java/turing/turing/domain/auth/AuthController.java
@@ -44,8 +44,7 @@ public class AuthController {
             @AuthenticationPrincipal CustomUserDetails customUserDetails,
             @RequestBody @Valid LoginRequest request) {
 
-        LoginResponse response = authService.login(request);
-        response.setProvider(customUserDetails.getProvider());
+        LoginResponse response = authService.login(customUserDetails, request);
 
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/turing/turing/domain/auth/AuthService.java
+++ b/src/main/java/turing/turing/domain/auth/AuthService.java
@@ -66,15 +66,12 @@ public class AuthService {
     }
 
     @Transactional
-    public LoginResponse login(LoginRequest request) {
-        String token = request.getAccessToken();
+    public LoginResponse login(CustomUserDetails customUserDetails, LoginRequest request) {
         String fcmToken = request.getFcmToken();
-        if (!jwtTokenProvider.validationToken(token)) {
-            throw new IllegalArgumentException("Invalid or expired token");
-        }
 
-        String email = jwtTokenProvider.getEmailFromToken(token);
-        Role role = jwtTokenProvider.getRoleFromToken(token);
+        String email = customUserDetails.getEmail();
+        Role role = customUserDetails.getRole();
+        Provider provider = customUserDetails.getProvider();
 
         if (role.equals(Role.TEACHER)) {
             Teacher teacher = teacherRepository.findByEmail(email)
@@ -89,6 +86,7 @@ public class AuthService {
                     .university(teacher.getUniversity())
                     .department(teacher.getDepartment())
                     .studentNumber(teacher.getStudentNumber())
+                    .provider(provider)
                     .build();
         }
 
@@ -101,6 +99,7 @@ public class AuthService {
                 .memberId(student.getId())
                 .firstName(student.getFirstName())
                 .lastName(student.getLastName())
+                .provider(provider)
                 .build();
     }
 

--- a/src/main/java/turing/turing/domain/auth/dto/LoginRequest.java
+++ b/src/main/java/turing/turing/domain/auth/dto/LoginRequest.java
@@ -5,6 +5,5 @@ import lombok.Getter;
 @Getter
 public class LoginRequest {
 
-    private String accessToken;
     private String fcmToken;
 }

--- a/src/main/java/turing/turing/domain/auth/dto/LoginResponse.java
+++ b/src/main/java/turing/turing/domain/auth/dto/LoginResponse.java
@@ -18,7 +18,4 @@ public class LoginResponse {
     private String studentNumber;
     private Provider provider;
 
-    public void setProvider(Provider provider) {
-        this.provider = provider;
-    }
 }

--- a/src/main/java/turing/turing/global/config/SecurityConfig.java
+++ b/src/main/java/turing/turing/global/config/SecurityConfig.java
@@ -16,7 +16,8 @@ public class SecurityConfig {
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
     private static final String[] AUTH_WHITELIST = {
-            "/api/auth/**",
+            "/api/auth/verify/**",
+            "/api/auth/reissue",
             "/api/members/signup",
             "/swagger-ui/**",
             "/v3/api-docs/**",


### PR DESCRIPTION
## 📄 Description

- close : #86 

## 📌 구현 내용
- 토큰 검증 과정을 service layer가 아닌 JwtAuthenticationFilter로 위임하였습니다.
    - 필터 적용 api에 /api/auth/login을 추가하였습니다.
    - 로그인 요청 body에 토큰 정보를 제거하였습니다.
- 불필요한 setProvider 메서드를 제거하였습니다.

