### PR TITLE
[Fix]: appleIdToken에서 email 추출 방법 변경

### DIFF
--- a/src/main/java/turing/turing/domain/auth/AuthService.java
+++ b/src/main/java/turing/turing/domain/auth/AuthService.java
@@ -1,6 +1,5 @@
 package turing.turing.domain.auth;
 
-import io.jsonwebtoken.Claims;
 import java.security.PublicKey;
 import java.util.Map;
 import java.util.Optional;
@@ -40,12 +39,12 @@ public class AuthService {
 
     public String verifyWithApple(final VerifyAppleRequest request) {
         String appleIdToken = request.getAppleIdToken();
-        Map<String, String> appleTokenHeader = appleTokenParser.parseHeader(appleIdToken);
-        ApplePublicKeys applePublicKeys = appleClient.getApplePublicKeys();
-        PublicKey publicKey = applePublicKeyGenerator.generate(appleTokenHeader, applePublicKeys);
-        Claims claims = appleTokenParser.extractClaims(appleIdToken, publicKey);
+//        Map<String, String> appleTokenHeader = appleTokenParser.parseHeader(appleIdToken);
+//        ApplePublicKeys applePublicKeys = appleClient.getApplePublicKeys();
+//        PublicKey publicKey = applePublicKeyGenerator.generate(appleTokenHeader, applePublicKeys);
+        Map<String, String> appleTokenPayload = appleTokenParser.extractClaims(appleIdToken);
 
-        return claims.get("email", String.class);
+        return appleTokenPayload.get("email");
     }
 
     public TokenResponse confirmAssign(String email, Provider provider) {

--- a/src/main/java/turing/turing/domain/auth/apple/ApplePublicKeys.java
+++ b/src/main/java/turing/turing/domain/auth/apple/ApplePublicKeys.java
@@ -17,7 +17,7 @@ public class ApplePublicKeys {
     public ApplePublicKey getMatchingKeyBy(final String alg, final String kid) {
         return keys.stream()
                 .filter(key -> key.isSameAlg(alg) && key.isSameKid(kid))
-                .findFirst()
+                .findAny()
                 .orElseThrow(() -> new RuntimeException("잘못된 토큰 형태입니다."));
     }
 }

--- a/src/main/java/turing/turing/domain/auth/apple/AppleTokenParser.java
+++ b/src/main/java/turing/turing/domain/auth/apple/AppleTokenParser.java
@@ -4,11 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.JwtException;
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.UnsupportedJwtException;
-import java.security.PublicKey;
+import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
@@ -26,7 +22,7 @@ public class AppleTokenParser {
     public Map<String, String> parseHeader(final String appleIdToken) {
         try {
             final String encodedHeader = appleIdToken.split(IDENTITY_TOKEN_VALUE_DELIMITER)[HEADER_INDEX];
-            final String decodedHeader = new String(Base64.getUrlDecoder().decode(encodedHeader));
+            final String decodedHeader = new String(Base64.getUrlDecoder().decode(encodedHeader), StandardCharsets.UTF_8);
             return objectMapper.readValue(decodedHeader, new TypeReference<>() {});
         } catch (JsonMappingException e) {
             throw new RuntimeException("올바르지 않은 appleToken");
@@ -35,19 +31,32 @@ public class AppleTokenParser {
         }
     }
 
-    public Claims extractClaims(final String appleIdToken, final PublicKey publicKey) {
+    public Map<String, String> extractClaims(final String appleIdToken) {
         try {
-            return Jwts.parser()
-                    .verifyWith(publicKey)
-                    .build()
-                    .parseSignedClaims(appleIdToken)
-                    .getPayload();
-        } catch (UnsupportedJwtException e) {
-            throw new UnsupportedJwtException("지원되지 않는 jwt 타입");
-        } catch (IllegalArgumentException e) {
-            throw new IllegalArgumentException("비어있는 jwt");
-        } catch (JwtException e) {
-            throw new JwtException("jwt 검증 오류");
+            final String encodedPayload = appleIdToken.split(IDENTITY_TOKEN_VALUE_DELIMITER)[1];
+            final String decodedPayload = new String(Base64.getUrlDecoder().decode(encodedPayload), StandardCharsets.UTF_8);
+            return objectMapper.readValue(decodedPayload, new TypeReference<>() {});
+        } catch (JsonMappingException e) {
+            throw new RuntimeException("올바르지 않은 appleToken");
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("디코드된 헤더 Map 형태로 분류 실패");
         }
     }
+//    public Claims extractClaims(final String appleIdToken, final PublicKey publicKey) {
+//        try {
+//            return Jwts.parser()
+//                    .verifyWith(publicKey)
+//                    .build()
+//                    .parseSignedClaims(appleIdToken)
+//                    .getPayload();
+//        } catch (UnsupportedJwtException e) {
+//            throw new UnsupportedJwtException("지원되지 않는 jwt 타입");
+//        } catch (IllegalArgumentException e) {
+//            throw new IllegalArgumentException("비어있는 jwt");
+//        } catch (ExpiredJwtException e) {
+//            throw new JwtException("유효기간 만료");
+//        } catch (JwtException e) {
+//            throw new JwtException("jwt 검증 오류");
+//        }
+//    }
 }


### PR DESCRIPTION
## 📄 Description

- close : #91

## 📌 구현 내용
- 기존방식
    - token에서 추출한 claim의 값을 통해 pubkey 생성 -> 해당 pubkey를 통해 appleIdToken에서 email을 추출
- 수정방식
    - token에서 email값 즉시 디코딩

## TODO
- 권장되는 방식이 아니므로 추후 수정 예정
