### PR TITLE
[Fix] 학생의 '회원 탈퇴'의 경우 '학생 연결 해제' 로직 적용 & cascade 옵션 제거

### DIFF
--- a/src/main/java/turing/turing/domain/member/MemberService.java
+++ b/src/main/java/turing/turing/domain/member/MemberService.java
@@ -10,6 +10,7 @@ import turing.turing.domain.member.dto.SignUpRequest;
 import turing.turing.domain.member.dto.SignUpResponse;
 import turing.turing.domain.student.Student;
 import turing.turing.domain.student.StudentRepository;
+import turing.turing.domain.studyRoom.StudyRoomRepository;
 import turing.turing.domain.teacher.Teacher;
 import turing.turing.domain.teacher.TeacherRepository;
 import turing.turing.global.exception.RestApiException;
@@ -23,6 +24,7 @@ public class MemberService {
 
     private final TeacherRepository teacherRepository;
     private final StudentRepository studentRepository;
+    private final StudyRoomRepository studyRoomRepository;
     private final JwtTokenProvider jwtTokenProvider;
 
     @Transactional
@@ -77,6 +79,22 @@ public class MemberService {
             teacherRepository.deleteById(memberId);
             return;
         }
+
+        // 학생의 경우 연결된 모든 과외공간에 대하여 학생 연결 해제 로직 적용
+        studyRoomRepository.findAllWIthStudentByStudentId(memberId)
+                .forEach(studyRoom -> {
+                    // 기존 학생의 정보를 통해 nonSignedUpStudent 생성
+                    Student nonSignUpStudent = new Student(
+                            studyRoom.getStudent().getFirstName(),
+                            studyRoom.getStudent().getLastName(),
+                            studyRoom.getStudent().getSchool(),
+                            studyRoom.getStudent().getYear(),
+                            studyRoom.getStudent().getPhone(),
+                            studyRoom.getStudent().getParentPhone()
+                    );
+                    studentRepository.save(nonSignUpStudent);
+                    studyRoom.disconnectStudent(nonSignUpStudent);
+                });
         studentRepository.deleteById(memberId);
     }
 

--- a/src/main/java/turing/turing/domain/question/Question.java
+++ b/src/main/java/turing/turing/domain/question/Question.java
@@ -64,8 +64,8 @@ public class Question extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "study_room_id", nullable = false)
     private StudyRoom studyRoom;
-  
-    @OneToMany(mappedBy = "question", cascade = CascadeType.REMOVE)
+
+    @OneToMany(mappedBy = "question")
     private List<Comment> comments = new ArrayList<>();
 
     @Builder

--- a/src/main/java/turing/turing/domain/question/QuestionRepository.java
+++ b/src/main/java/turing/turing/domain/question/QuestionRepository.java
@@ -11,6 +11,9 @@ import java.util.Optional;
 
 public interface QuestionRepository extends JpaRepository<Question, Long> {
 
+    @Query("select q from Question q left join fetch q.comments WHERE q.id = :id")
+    Optional<Question> findWithCommentsById(@Param("id") Long id);
+
     // 선생님용 질문 조회
     @Query(value = "select q from Question q join q.studyRoom s where s.teacher = :teacher")
     List<Question> findAllQuestionByTeacher(@Param(value = "teacher") Teacher teacher);

--- a/src/main/java/turing/turing/domain/question/QuestionService.java
+++ b/src/main/java/turing/turing/domain/question/QuestionService.java
@@ -59,11 +59,10 @@ public class QuestionService {
     }
 
     public QuestionWithCommentsResDto getDetailedQuestion(Long questionId){
-        Question question = questionRepository.findById(questionId)
+        Question question = questionRepository.findWithCommentsById(questionId)
                 .orElseThrow(() -> new RestApiException(QuestionErrorCode.QUESTION_NOT_FOUND));
-        List<Comment> commentList = commentRepository.findAllByQuestion(question);
 
-        return QuestionWithCommentsResDto.of(question, commentList);
+        return QuestionWithCommentsResDto.of(question);
     }
 
     @Transactional

--- a/src/main/java/turing/turing/domain/question/dto/response/QuestionWithCommentsResDto.java
+++ b/src/main/java/turing/turing/domain/question/dto/response/QuestionWithCommentsResDto.java
@@ -17,7 +17,7 @@ public record QuestionWithCommentsResDto(
         Integer commentCount,
         List<CommentResDto> commentList
 ) {
-    public static QuestionWithCommentsResDto of(Question question, List<Comment> commentList){
+    public static QuestionWithCommentsResDto of(Question question){
         return new QuestionWithCommentsResDto(
                 question.getId(),
                 question.getTitle(),
@@ -27,7 +27,7 @@ public record QuestionWithCommentsResDto(
                 question.getSolveStatus(),
                 question.getPinStatus(),
                 question.getCommentCount(),
-                commentList.stream().map(CommentResDto::of).toList()
+                question.getComments().stream().map(CommentResDto::of).toList()
         );
     }
 }

--- a/src/main/java/turing/turing/domain/studyRoom/StudyRoom.java
+++ b/src/main/java/turing/turing/domain/studyRoom/StudyRoom.java
@@ -7,10 +7,6 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import turing.turing.domain.BaseEntity;
-import turing.turing.domain.code.ConnectionCode;
-import turing.turing.domain.exam.Exam;
-import turing.turing.domain.question.Question;
-import turing.turing.domain.schedule.Schedule;
 import turing.turing.domain.student.Student;
 import turing.turing.domain.studyTime.StudyTime;
 import turing.turing.domain.teacher.Teacher;
@@ -55,21 +51,8 @@ public class StudyRoom extends BaseEntity {
     @Column(name = "wage", nullable = false)
     private Integer wage;
   
-    @OneToMany(mappedBy = "studyRoom", cascade = CascadeType.REMOVE)
+    @OneToMany(mappedBy = "studyRoom")
     private List<StudyTime> studyTimes = new ArrayList<>();
-
-    @OneToOne(mappedBy = "studyRoom", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
-    private ConnectionCode connectionCode;
-
-    @OneToMany(mappedBy = "studyRoom", cascade = CascadeType.REMOVE)
-    private List<Schedule> schedules = new ArrayList<>();
-
-    @OneToMany(mappedBy = "studyRoom", cascade = CascadeType.REMOVE)
-    private List<Exam> exams = new ArrayList<>();
-
-
-    @OneToMany(mappedBy = "studyRoom", cascade = CascadeType.REMOVE)
-    private List<Question> questions = new ArrayList<>();
 
     public StudyRoom(String subject, Integer baseSession, Integer wage, Teacher teacher, Student student) {
         this.subject = subject;

--- a/src/main/java/turing/turing/domain/studyRoom/StudyRoomRepository.java
+++ b/src/main/java/turing/turing/domain/studyRoom/StudyRoomRepository.java
@@ -45,4 +45,7 @@ public interface StudyRoomRepository extends JpaRepository<StudyRoom, Long> {
 
     @Query("SELECT s FROM StudyRoom s WHERE s.teacher.id = :teacherId")
     List<StudyRoom> findAllByTeacherId(Long teacherId);
+
+    @Query("SELECT sr FROM StudyRoom sr join fetch sr.student s WHERE s.id = :studentId")
+    List<StudyRoom> findAllWIthStudentByStudentId(Long studentId);
 }


### PR DESCRIPTION
## 📄 Description

- close : #96 

> 과외 선생님이 탈퇴한 경우는 과외 공간을 포함한 연관되어 있는 엔티티가 제거되지만, 학생의 '회원 탈퇴'의 경우는 과외 공간을 제거하지 않고 연결된 모든 과외공간에 대하여 '학생 연결 해제' 로직을 적용하기로 합니다.
> 추가적으로 데이터베이스에 `ON DELETE CASCADE` 옵션과 함께 외래키 제약 조건을 설정하기로 하였으므로, 엔티티 내의 cascade 옵션을 제거하도록 합니다.

## 📌 구현 내용

- [x] 학생의 '회원 탈퇴'의 경우 연결된 모든 과외공간에 대하여 '학생 연결 해제' 로직 적용
- [x] 엔티티 내의 cascade 옵션을 제거
- [x] 질문 상세 조회 성능 최적화

## 🌱 ETC

추가적으로 질문 상세 조회에서 질문, 답변 각각 두 개의 쿼리가 나가는 것을 확인해 left join fetch 사용하여 한 번의 쿼리로 가져오도록 최적화하였습니다.