### PR TITLE
[Fix] AccessToken 재발급 요청의 json body 값 읽지 못하는 버그 해결 & AppleIdToken에서 email 추출 로직 이전으로 복구

### DIFF
--- a/src/main/java/turing/turing/domain/auth/AuthService.java
+++ b/src/main/java/turing/turing/domain/auth/AuthService.java
@@ -1,5 +1,6 @@
 package turing.turing.domain.auth;
 
+import io.jsonwebtoken.Claims;
 import java.security.PublicKey;
 import java.util.Map;
 import java.util.Optional;
@@ -39,12 +40,12 @@ public class AuthService {
 
     public String verifyWithApple(final VerifyAppleRequest request) {
         String appleIdToken = request.getAppleIdToken();
-//        Map<String, String> appleTokenHeader = appleTokenParser.parseHeader(appleIdToken);
-//        ApplePublicKeys applePublicKeys = appleClient.getApplePublicKeys();
-//        PublicKey publicKey = applePublicKeyGenerator.generate(appleTokenHeader, applePublicKeys);
-        Map<String, String> appleTokenPayload = appleTokenParser.extractClaims(appleIdToken);
+        Map<String, String> appleTokenHeader = appleTokenParser.parseHeader(appleIdToken);
+        ApplePublicKeys applePublicKeys = appleClient.getApplePublicKeys();
+        PublicKey publicKey = applePublicKeyGenerator.generate(appleTokenHeader, applePublicKeys);
+        Claims claims = appleTokenParser.extractClaims(appleIdToken, publicKey);
 
-        return appleTokenPayload.get("email");
+        return claims.get("email", String.class);
     }
 
     public TokenResponse confirmAssign(String email, Provider provider) {

--- a/src/main/java/turing/turing/domain/auth/AuthService.java
+++ b/src/main/java/turing/turing/domain/auth/AuthService.java
@@ -102,6 +102,7 @@ public class AuthService {
                 .build();
     }
 
+    @Transactional
     public TokenResponse reissue(TokenReIssueRequest request) {
         String token = request.getRefreshToken();
 

--- a/src/main/java/turing/turing/domain/auth/apple/AppleTokenParser.java
+++ b/src/main/java/turing/turing/domain/auth/apple/AppleTokenParser.java
@@ -4,7 +4,13 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.UnsupportedJwtException;
 import java.nio.charset.StandardCharsets;
+import java.security.PublicKey;
 import java.util.Base64;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
@@ -31,32 +37,21 @@ public class AppleTokenParser {
         }
     }
 
-    public Map<String, String> extractClaims(final String appleIdToken) {
+    public Claims extractClaims(final String appleIdToken, final PublicKey publicKey) {
         try {
-            final String encodedPayload = appleIdToken.split(IDENTITY_TOKEN_VALUE_DELIMITER)[1];
-            final String decodedPayload = new String(Base64.getUrlDecoder().decode(encodedPayload), StandardCharsets.UTF_8);
-            return objectMapper.readValue(decodedPayload, new TypeReference<>() {});
-        } catch (JsonMappingException e) {
-            throw new RuntimeException("올바르지 않은 appleToken");
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException("디코드된 헤더 Map 형태로 분류 실패");
+            return Jwts.parser()
+                    .verifyWith(publicKey)
+                    .build()
+                    .parseSignedClaims(appleIdToken)
+                    .getPayload();
+        } catch (UnsupportedJwtException e) {
+            throw new UnsupportedJwtException("지원되지 않는 jwt 타입");
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("비어있는 jwt");
+        } catch (ExpiredJwtException e) {
+            throw new JwtException("유효기간 만료");
+        } catch (JwtException e) {
+            throw new JwtException("jwt 검증 오류");
         }
     }
-//    public Claims extractClaims(final String appleIdToken, final PublicKey publicKey) {
-//        try {
-//            return Jwts.parser()
-//                    .verifyWith(publicKey)
-//                    .build()
-//                    .parseSignedClaims(appleIdToken)
-//                    .getPayload();
-//        } catch (UnsupportedJwtException e) {
-//            throw new UnsupportedJwtException("지원되지 않는 jwt 타입");
-//        } catch (IllegalArgumentException e) {
-//            throw new IllegalArgumentException("비어있는 jwt");
-//        } catch (ExpiredJwtException e) {
-//            throw new JwtException("유효기간 만료");
-//        } catch (JwtException e) {
-//            throw new JwtException("jwt 검증 오류");
-//        }
-//    }
 }

--- a/src/main/java/turing/turing/domain/auth/dto/TokenReIssueRequest.java
+++ b/src/main/java/turing/turing/domain/auth/dto/TokenReIssueRequest.java
@@ -1,11 +1,11 @@
 package turing.turing.domain.auth.dto;
 
-import lombok.AllArgsConstructor;
+import jakarta.validation.constraints.NotEmpty;
 import lombok.Getter;
 
 @Getter
-@AllArgsConstructor
 public class TokenReIssueRequest {
 
+    @NotEmpty
     private String refreshToken;
 }


### PR DESCRIPTION
## 📄 Description

- close : #99 

## 📌 구현 내용
- RefreshToken 을 포함한 요청 Dto에서 AllArgs 어노테이션을 제거하였습니다
    - 이전의 VerifyAppleRequest와 동일 원인
- 서버 내에서 애플 서버와의 통신을 통해 토큰을 검증하도록 하였습니다.
