### PR TITLE
[Fix] Student 엔티티의 fcm_token 중복 필드 제거

### DIFF
--- a/src/main/java/turing/turing/domain/auth/CustomUserDetailService.java
+++ b/src/main/java/turing/turing/domain/auth/CustomUserDetailService.java
@@ -30,7 +30,7 @@ public class CustomUserDetailService implements UserDetailsService {
 
     private Object findByEmail(String email) {
         Optional<Teacher> member = teacherRepository.findByEmail(email);
-        return Objects.requireNonNullElseGet(member, () -> studentRepository.findByEmail(email)
+        return Objects.requireNonNullElseGet(member.orElse(null), () -> studentRepository.findByEmail(email)
                 .orElseThrow(() -> new RestApiException(CommonErrorCode.NOT_FOUND)));
     }
 }

--- a/src/main/java/turing/turing/domain/notebook/NotebookController.java
+++ b/src/main/java/turing/turing/domain/notebook/NotebookController.java
@@ -58,7 +58,6 @@ public class NotebookController {
 
     @Operation(summary = "알림장 생성")
     @PostMapping("")
-
     public ResponseEntity<CreateNotebookResponse> createNotebook(
             @AuthenticationPrincipal CustomUserDetails customUserDetails, @RequestBody CreateNotebookRequest request) {
         CreateNotebookResponse response = notebookService.createNotebook(request);

--- a/src/main/java/turing/turing/domain/student/Student.java
+++ b/src/main/java/turing/turing/domain/student/Student.java
@@ -52,10 +52,6 @@ public class Student extends Member {
     @Column(name = "parent_phone", length = 30)
     private String parentPhone;
 
-    @Size(max = 300)
-    @Column(name = "fcm_token", length = 300)
-    private String fcmToken;
-
     // 학생 가입용
     @Builder
     public Student(String email, Role role, Provider provider, String firstName, String lastName) {


### PR DESCRIPTION
## 📄 Description

- close : #103 

## 📌 구현 내용
- Student 엔티티의 fcmToken 필드가, 상속받는 member 클래스에도 중복 존재하여 이를 제거하였습니다.
- 이메일을 사용하여 학생/선생 객체를 조회할 때, Optional 내부의 값을 확인하여 null인 경우 두번째 인자인 supplier 메서드의 결과가 반환되도록 수정하였습니다.
    - 기존에도 유사하게 Optional 객체가 null이 아닌 경우 첫 번째 값을 응답하도록 하였으나 Optional 객체 내부의 값이 null인 것이지 객체 자체는 null 값이 아니므로 해당 세부 로직을 수정하였습니다.